### PR TITLE
Solved bugs for request URL in LiCSBAS01_get_geotiff.py

### DIFF
--- a/bin/LiCSBAS01_get_geotiff.py
+++ b/bin/LiCSBAS01_get_geotiff.py
@@ -211,7 +211,7 @@ def main(argv=None):
     else:
         ### Get available dates
         print('Searching latest epoch for mli...', flush=True)
-        url = os.path.join(LiCSARweb, trackID, frameID, 'epochs', '')
+        url = os.path.join(LiCSARweb, trackID, frameID, 'epochs/')
         response = requests.get(url)
         
         response.encoding = response.apparent_encoding #avoid garble
@@ -227,7 +227,8 @@ def main(argv=None):
         for i, imd in enumerate(reversed(_imdates)):
             if np.mod(i, 10) == 0:
                 print("\r  {0:3}/{1:3}".format(i, len(_imdates)), end='', flush=True)
-            url_epoch = os.path.join(url, imd, '')
+            imd_mod = imd + "/"
+            url_epoch = os.path.join(url, imd_mod)
             response = requests.get(url_epoch)
             response.encoding = response.apparent_encoding #avoid garble
             html_doc = response.text
@@ -256,7 +257,7 @@ def main(argv=None):
 
         ### Get available dates
         print('\nDownload GACOS data', flush=True)
-        url = os.path.join(LiCSARweb, trackID, frameID, 'epochs', '')
+        url = os.path.join(LiCSARweb, trackID, frameID, 'epochs/')
         response = requests.get(url)
         response.encoding = response.apparent_encoding #avoid garble
         html_doc = response.text
@@ -320,7 +321,7 @@ def main(argv=None):
     #%% unw and cc
     ### Get available dates
     print('\nDownload geotiff of unw and cc', flush=True)
-    url_ifgdir = os.path.join(LiCSARweb, trackID, frameID, 'interferograms', '')
+    url_ifgdir = os.path.join(LiCSARweb, trackID, frameID, 'interferograms/')
     response = requests.get(url_ifgdir)
     
     response.encoding = response.apparent_encoding #avoid garble


### PR DESCRIPTION
There is an issue with the file LiCSBAS01_get_geotiff.py. This file contains a bug when I run LiCSBAS to retrieve data for any time interval and parameter in batch_LiCSBAS.sh, where the file calls LiCSBAS01_get_geotiff.py. Specifically, the issue is as follows:
![Screenshot (186)](https://github.com/user-attachments/assets/dc59a517-b66f-427c-b8e5-60da8a24bbdc)

The problem, as we can see, occurs when the file requests data from the given URL. Therefore, I believe the error lies in the URL code string within the file. I modified the code in LiCSBAS01_get_geotiff.py, specifically in the sections that handle requests for MLI data, GACOS data, and interferogram data. There is something wrong, maybe the website now is up to date so this file can't parse the HTML properly.