### PR TITLE
Mitigate stuck risk in multiprocessing

### DIFF
--- a/LiCSBAS_lib/LiCSBAS_inv_lib.py
+++ b/LiCSBAS_lib/LiCSBAS_inv_lib.py
@@ -143,7 +143,7 @@ def invert_nsbas(unw, G, dt_cum, gamma, n_core, gpu):
 
 def censored_lstsq_slow_para_wrapper(i):
     ### Use global value
-    if np.mod(i, 1000) == 0:
+    if np.mod(i, 10000) == 0:
         print('  Running {0:6}/{1:6}th point...'.format(i, unw_tmp.shape[1]), flush=True)
     m = mask[:,i] # drop rows where mask is zero
     try:
@@ -216,7 +216,7 @@ def invert_nsbas_wls(unw, var, G, dt_cum, gamma, n_core):
 
 def wls_nsbas(i):
     ### Use global value of Gall, unw_tmp, mask
-    if np.mod(i, 1000) == 0:
+    if np.mod(i, 10000) == 0:
         print('  Running {0:6}/{1:6}th point...'.format(i, unw_tmp.shape[1]), flush=True)
 
     ## Weight unw and G
@@ -533,7 +533,7 @@ def censored_lstsq_slow(A, B, M):
 
     X = np.empty((A.shape[1], B.shape[1]))
     for i in range(B.shape[1]):
-        if np.mod(i, 1000) == 0:
+        if np.mod(i, 10000) == 0:
              print('\r  Running {0:6}/{1:6}th point...'.format(i, B.shape[1]), end='', flush=True)
 
         m = M[:,i] # drop rows where mask is zero

--- a/LiCSBAS_lib/LiCSBAS_loop_lib.py
+++ b/LiCSBAS_lib/LiCSBAS_loop_lib.py
@@ -145,5 +145,5 @@ def make_loop_png(unw12, unw23, unw13, loop_ph, png, titles4, cycle):
 
     plt.tight_layout()
     plt.savefig(png)
-    plt.close()
+    plt.close(fig)
 

--- a/LiCSBAS_lib/LiCSBAS_plot_lib.py
+++ b/LiCSBAS_lib/LiCSBAS_plot_lib.py
@@ -55,7 +55,7 @@ def make_im_png(data, pngfile, cmap, title, vmin=None, vmax=None, cbar=True):
     if cbar: fig.colorbar(im)
 
     plt.savefig(pngfile)
-    plt.close()
+    plt.close(fig)
 
     return
 
@@ -87,6 +87,7 @@ def make_3im_png(data3, pngfile, cmap, title3, vmin=None, vmax=None, cbar=True):
             data3[i][data3[i]==0] = np.nan # as no data
         ax = fig.add_subplot(1, 3, i+1) #index start from 1
         im = ax.imshow(data3[i], vmin=vmin, vmax=vmax, cmap=cmap, interpolation=interp)
+        data3[i] = [] # delete to save memory
         ax.set_title(title3[i])
         ax.set_xticklabels([])
         ax.set_yticklabels([])
@@ -94,7 +95,7 @@ def make_3im_png(data3, pngfile, cmap, title3, vmin=None, vmax=None, cbar=True):
 
     plt.tight_layout()
     plt.savefig(pngfile)
-    plt.close()
+    plt.close(fig)
 
     return
 
@@ -189,7 +190,7 @@ def plot_hgt_corr(data_bf, fit_hgt, hgt, title, pngfile):
     ax.legend(loc='upper right')
     fig.tight_layout()
     fig.savefig(pngfile)
-    plt.close()
+    plt.close(fig)
 
     return
 
@@ -288,4 +289,4 @@ def plot_network(ifgdates, bperp, rm_ifgdates, pngfile, plot_bad=True):
 
     ### Save
     plt.savefig(pngfile)
-    plt.close()
+    plt.close(fig)

--- a/batch_LiCSBAS.sh
+++ b/batch_LiCSBAS.sh
@@ -21,7 +21,7 @@ end_step="16"	# 01-05, 11-16
 
 nlook="1"	# multilook factor, used in step02
 GEOCmldir="GEOCml${nlook}"	# If start from 11 or later after doing 03-05, use e.g., GEOCml${nlook}GACOSmaskclip
-n_para="" # Number of paralell processing in step 02-05,12,13,16. default: number of usable CPU
+n_para="" # Number of paralell processing in step 02-05,12,13,16. default: number of usable CPU-1
 gpu="n"	# y/n
 check_only="n" # y/n. If y, not run scripts and just show commands to be done
 
@@ -76,29 +76,29 @@ p01_n_para=""	# default: 4
 p02_GEOCdir=""	# default: GEOC
 p02_GEOCmldir=""	# default: GEOCml$nlook
 p02_freq=""	# default: 5.405e9 Hz
-p02_n_para=""   # default: # of usable CPU
+p02_n_para=""   # default: # of usable CPU-1
 p03_inGEOCmldir=""	# default: $GEOCmldir
 p03_outGEOCmldir_suffix="" # default: GACOS
 p03_fillhole="y"	# y/n. default: n
 p03_gacosdir=""	# default: GACOS
-p03_n_para=""   # default: # of usable CPU
+p03_n_para=""   # default: # of usable CPU-1
 p04_inGEOCmldir=""	# default: $GEOCmldir
 p04_outGEOCmldir_suffix="" # default: mask
-p04_n_para=""   # default: # of usable CPU
+p04_n_para=""   # default: # of usable CPU-1
 p05_inGEOCmldir=""      # default: $GEOCmldir
 p05_outGEOCmldir_suffix="" # default: clip
-p05_n_para=""   # default: # of usable CPU
+p05_n_para=""   # default: # of usable CPU-1
 p11_GEOCmldir=""	# default: $GEOCmldir
 p11_TSdir=""	# default: TS_$GEOCmldir
 p12_GEOCmldir=""        # default: $GEOCmldir
 p12_TSdir=""    # default: TS_$GEOCmldir
-p12_n_para=""	# default: # of usable CPU
+p12_n_para=""	# default: # of usable CPU-1
 p13_GEOCmldir=""        # default: $GEOCmldir
 p13_TSdir=""    # default: TS_$GEOCmldir
 p13_inv_alg=""	# LS (default) or WLS
 p13_mem_size=""	# default: 8000 (MB)
 p13_gamma=""	# default: 0.0001
-p13_n_para=""	# default: # of usable CPU
+p13_n_para=""	# default: # of usable CPU-1
 p13_n_unw_r_thre=""	# defualt: 1
 p13_keep_incfile="n"	# y/n. default: n
 p14_TSdir=""    # default: TS_$GEOCmldir
@@ -110,7 +110,7 @@ p15_keep_isolated="n"	# y/n. default: n
 p15_noautoadjust="n" # y/n. default: n
 p16_TSdir=""    # default: TS_$GEOCmldir
 p16_nomask="n"	# y/n. default: n
-p16_n_para=""   # default: # of usable CPU
+p16_n_para=""   # default: # of usable CPU-1
 
 
 #############################

--- a/bin/LiCSBAS02_ml_prep.py
+++ b/bin/LiCSBAS02_ml_prep.py
@@ -38,7 +38,7 @@ LiCSBAS02_ml_prep.py -i GEOCdir [-o GEOCmldir] [-n nlook] [--freq float] [--n_pa
  -n  Number of donwsampling factor (Default: 1, no donwsampling)
  --freq    Radar frequency in Hz (Default: 5.405e9 for Sentinel-1)
            (e.g., 1.27e9 for ALOS, 1.2575e9 for ALOS-2/U, 1.2365e9 for ALOS-2/{F,W})
- --n_para  Number of parallel processing (Default: # of usable CPU)
+ --n_para  Number of parallel processing (Default: # of usable CPU-1)
 
 """
 
@@ -85,9 +85,9 @@ def main(argv=None):
     nlook = 1
     radar_freq = 5.405e9
     try:
-        n_para = len(os.sched_getaffinity(0))
+        n_para = max(len(os.sched_getaffinity(0))-1, 1)
     except:
-        n_para = multi.cpu_count()
+        n_para = max(multi.cpu_count()-1, 1)
 
     cmap_wrap = tools_lib.get_cmap('cm_insar')
     cycle = 3

--- a/bin/LiCSBAS04op_mask_unw.py
+++ b/bin/LiCSBAS04op_mask_unw.py
@@ -30,7 +30,7 @@ LiCSBAS04op_mask_unw.py -i in_dir -o out_dir [-c coh_thre] [-r x1:x2/y1:y2] [-f 
  -r  Range to be masked. Index starts from 0.
      0 for x2/y2 means all. (i.e., 0:0/0:0 means whole area).
  -f  Text file of a list of ranges to be masked (format is x1:x2/y1:y2)
- --n_para  Number of parallel processing (Default: # of usable CPU)
+ --n_para  Number of parallel processing (Default: # of usable CPU - 1)
 
  Note: either -c, -r or -f must be specified.
 
@@ -77,9 +77,9 @@ def main(argv=None):
     ex_range_str = []
     ex_range_file = []
     try:
-        n_para = len(os.sched_getaffinity(0))
+        n_para = max(len(os.sched_getaffinity(0))-1, 1)
     except:
-        n_para = multi.cpu_count()
+        n_para = max(multi.cpu_count()-1, 1)
 
     cmap_noise = 'viridis'
     cmap_wrap = tools_lib.get_cmap('cm_insar')

--- a/bin/LiCSBAS05op_clip_unw.py
+++ b/bin/LiCSBAS05op_clip_unw.py
@@ -32,7 +32,7 @@ LiCSBAS05op_clip_unw.py -i in_dir -o out_dir [-r x1:x2/y1:y2] [-g lon1/lon2/lat1
  -r  Range to be clipped. Index starts from 0.
      0 for x2/y2 means all. (i.e., 0:0/0:0 means whole area).
  -g  Range to be clipped in geographical coordinates (deg).
- --n_para  Number of parallel processing (Default: # of usable CPU)
+ --n_para  Number of parallel processing (Default: # of usable CPU-1)
 
 """
 
@@ -78,9 +78,9 @@ def main(argv=None):
     range_str = []
     range_geo_str = []
     try:
-        n_para = len(os.sched_getaffinity(0))
+        n_para = max(len(os.sched_getaffinity(0))-1, 1)
     except:
-        n_para = multi.cpu_count()
+        n_para = max(multi.cpu_count()-1, 1)
 
     q = multi.get_context('fork')
     cmap_wrap = tools_lib.get_cmap('cm_insar')

--- a/bin/LiCSBAS12_loop_closure.py
+++ b/bin/LiCSBAS12_loop_closure.py
@@ -56,7 +56,7 @@ LiCSBAS12_loop_closure.py -d ifgdir [-t tsadir] [-l loop_thre] [--multi_prime]
  --multi_prime  Multi Prime mode (take into account bias in loop)
  --rm_ifg_list  Manually remove ifgs listed in a file
  --rm_noloop_ifg  Remove ifgs with no loop
- --n_para  Number of parallel processing (Default: # of usable CPU)
+ --n_para  Number of parallel processing (Default: # of usable CPU-1)
 
 """
 
@@ -107,9 +107,9 @@ def main(argv=None):
     rm_noloop_ifg = False
 
     try:
-        n_para = len(os.sched_getaffinity(0))
+        n_para = max(len(os.sched_getaffinity(0))-1, 1)
     except:
-        n_para = multi.cpu_count()
+        n_para = max(multi.cpu_count()-1, 1)
 
     cycle = 3 # 2pi*3/cycle
     cmap_noise = 'viridis'

--- a/bin/LiCSBAS_color_geotiff.py
+++ b/bin/LiCSBAS_color_geotiff.py
@@ -153,7 +153,7 @@ if __name__ == "__main__":
         cbarfile = "{}_{}_{}.pdf".format(cmap_name, cmin, cmax)
         plt.tight_layout()
         plt.savefig(cbarfile, transparent=True)
-        plt.close()
+        plt.close(fig)
 
 
     #%% Remove intermediate files

--- a/bin/LiCSBAS_color_geotiff2tiles.py
+++ b/bin/LiCSBAS_color_geotiff2tiles.py
@@ -22,7 +22,7 @@ LiCSBAS_color_geotiff2tiles.py -i infile [-o outdir] [--zmin int] [--zmax int]
          12 (pixel spacing <= 160m)
          11 (pixel spacing >  160m)
  --xyz     Output XYZ tiles instead of TMS (opposite Y)
- --n_para  Number of parallel processing (Default: # of usable CPU)
+ --n_para  Number of parallel processing (Default: # of usable CPU-1)
            Available only in gdal>=2.3
 
 """
@@ -68,9 +68,9 @@ def main(argv=None):
     zmax = []
     tms_flag = True
     try:
-        n_para = len(os.sched_getaffinity(0))
+        n_para = max(len(os.sched_getaffinity(0))-1, 1)
     except:
-        n_para = multi.cpu_count()
+        n_para = max(multi.cpu_count()-1, 1)
 
     q = multi.get_context('fork')
 


### PR DESCRIPTION
## Issue

https://github.com/yumorishita/LiCSBAS/issues/244#issuecomment-1500877478

LiCSBAS processing sometimes gets stuck, especially when
- The input data size (i.e., AOI size, number of dates) is large
- The machine memory is small

The issue often occurs in step 16, which consumes a large amount of memory, but can also happen in other steps (e.g., step 03, step 13).

I have investigated the cause and found that
- The stuck issue always happens in multiprocessing
- The stuck issue happens when the memory usage becomes nearly 100% (or actually >100%)

## Modification

To mitigate the risk of being stuck,
- The default n_para is reduced from the number of usable CPU to the number of usable CPU - 1 in all steps
- Reduce memory usage by deleting unnecessary variables
- Reduce memory usage by modifying algorithms in step16
- Implement n_para adjustment depending on the available memory size in step 16

## Note

The stuck issue can still happen even after this modification. In that case, manually setting `n_para=1` can solve the issue.