### PR TITLE
Fix IndexError in step16 for temporally isolated epochs

### DIFF
--- a/bin/LiCSBAS16_filt_ts.py
+++ b/bin/LiCSBAS16_filt_ts.py
@@ -106,7 +106,7 @@ def main(argv=None):
         argv = sys.argv
 
     start = time.time()
-    ver="1.6.2"; date=20250725; author="Y. Morishita"
+    ver="1.6.3"; date=20260805; author="Y. Morishita"
     print("\n{} ver{} {} {}".format(os.path.basename(argv[0]), ver, date, author), flush=True)
     print("{} {}".format(os.path.basename(argv[0]), ' '.join(argv[1:])), flush=True)
 
@@ -520,6 +520,10 @@ def main(argv=None):
 
     ### Find stable reference
     min_rms = np.nanmin(rms_cum_wrt_med)
+    if np.isnan(min_rms):
+        print('\nERROR: All pixels in rms_cum_wrt_med are nan. Cannot find '
+              'a stable reference point.', file=sys.stderr)
+        return 1
     refy1s, refx1s = np.where(rms_cum_wrt_med==min_rms)
     refy1s, refx1s = refy1s[0], refx1s[0] ## Only first index
     refy2s, refx2s = refy1s+1, refx1s+1
@@ -764,6 +768,11 @@ def filter_wrapper(i):
         ## Limit reading data within filtwidth_yr*4
         ixs = time_diff_sq < (filtwidth_yr*4)**2
 
+        if ixs.sum() == 1:  ## only itself within the temporal filter window
+            print('  WARNING: {} is temporally isolated (no other images '
+                  'within filtwidth_yr*4). No temporal filter applied.'
+                  .format(imdates[i]), flush=True)
+
         raw_temporal_weights = np.exp(-time_diff_sq[ixs] / (2 * filtwidth_yr**2)) #len(ixs)
 
         valid_data_mask = ~np.isnan(cum[ixs, :, :]) #len(ixs), length, width
@@ -787,7 +796,7 @@ def filter_wrapper(i):
         _cum_filt = cum[i, :, :] ## No spatial
     else:
         with warnings.catch_warnings(): ## To silence warning
-            if i ==0: cum_hpt = cum_hpt+sys.float_info.epsilon ##To distinguish from 0 of filtered nodata
+            cum_hpt = cum_hpt+sys.float_info.epsilon ##To distinguish from 0 of filtered nodata
 
 #                warnings.simplefilter('ignore', FutureWarning)
             warnings.simplefilter('ignore', RuntimeWarning)


### PR DESCRIPTION
## Problem

`LiCSBAS16_filt_ts.py` crashes with `IndexError: index 0 is out of bounds for axis 0 with size 0` at the stable reference point search when the time series contains a temporally isolated epoch (no other images within `filtwidth_yr*4`).

Example: an epoch 270 days from the previous and 954 days from the next image, with `-y 0.15` (window = 219 days).

## Cause

For an isolated epoch, only the epoch itself falls in the temporal filter window, so `cum_lpt == cum[i]` and `cum_hpt` becomes exactly zero at all pixels. After the spatial filter, the nodata identification `cum_hptlps[cum_hptlps == 0] = np.nan` then flags the entire image as nan, making `cum_filt` of that epoch all nan. The RMS map for reference point selection accumulates nan everywhere, `np.where` returns empty arrays, and indexing `[0]` raises IndexError.

## Fix

- Apply the epsilon offset (which distinguishes real zeros from filtered nodata) to all images, not only `i == 0`. An isolated epoch then correctly ends up unfiltered (`cum_filt[i] = cum[i]`), which is mathematically consistent since its HP-in-time component is zero.
- Print a warning when an epoch is temporally isolated.
- Exit with an informative error message instead of IndexError if `rms_cum_wrt_med` is all nan.

Verified on real data that the epsilon (2.2e-16) has no effect on normal images: the zero/nan masks and output values of the spatial filter are identical with and without it, because the epsilon only rides on valid input pixels and cannot turn a true nodata zero into a nonzero value.

## Verification

On the affected dataset (49 epochs incl. isolated 20220908, `-y 0.15`):
- step16 finishes successfully with the warning shown and a reference point selected
- `cum_filt` of the isolated epoch is no longer all nan and equals `cum[i]` minus the reference value (max diff = 2.2e-16)
- Normal epochs are filtered exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
