### PR TITLE
Add pytest test suite and GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: .github/workflows/environment-ci.yml
+          cache-environment: true
+      - name: Run tests
+        env:
+          MPLBACKEND: Agg
+          QT_QPA_PLATFORM: offscreen
+        run: python -m pytest -v

--- a/.github/workflows/environment-ci.yml
+++ b/.github/workflows/environment-ci.yml
@@ -1,0 +1,19 @@
+# Conda environment for CI only (see ci.yml).
+# The user-facing environment file is LiCSBAS.yml; this one uses
+# conda-forge and adds pytest.
+name: licsbas-ci
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - numpy=1.26.*
+  - matplotlib=3.7.*
+  - gdal=3.6.*
+  - h5py
+  - astropy
+  - beautifulsoup4
+  - psutil
+  - requests
+  - shapely
+  - statsmodels
+  - pytest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LiCSBAS2
 
+![CI](https://github.com/yumorishita/LiCSBAS2/actions/workflows/ci.yml/badge.svg)
+
 **[LiCSBAS](https://github.com/yumorishita/LiCSBAS)** is an open-source package in Python and bash to carry out InSAR time series analysis using LiCSAR products (i.e., unwrapped interferograms and coherence) which are freely available on the [COMET-LiCS web portal](https://comet.nerc.ac.uk/COMET-LiCS-portal/). **LiCSBAS2** is the successor of LiCSBAS.
 
 Users can easily derive the time series and velocity of the displacement if sufficient LiCSAR products are available in the area of interest. LiCSBAS also contains visualization tools to interactively display the time series of displacement to help investigation and interpretation of the results.
@@ -15,6 +17,10 @@ THIS IS RESEARCH CODE PROVIDED TO YOU "AS IS" WITH NO WARRANTIES OF CORRECTNESS.
 WIP
 
 If you have found an issue or bug, please report it on the [issues page](https://github.com/yumorishita/LiCSBAS2/issues).
+
+## Tests
+
+See [tests/README.md](tests/README.md). Tests run automatically on GitHub Actions for pushes and pull requests.
 
 ## Citations
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+pythonpath = LiCSBAS_lib
+markers =
+    smoke: end-to-end bin/ script smoke tests (slower, run subprocesses)
+addopts = -ra

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,9 +32,3 @@ calls to the nonexistent `np.linalg.leastsq` in
 `LiCSBAS_inv_lib.censored_lstsq*`). They are expected to fail until the
 bugs are fixed in separate PRs; when a fix lands, the test starts
 XPASS-ing and must be updated to assert the correct behavior.
-
-## Manual end-to-end tests
-
-`bin/test_LiCSBAS.sh` and `bin/test2_LiCSBAS.sh` (if present) download a
-real LiCSAR frame and run the full batch pipeline. They are
-network-heavy manual tests, intentionally outside pytest.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,40 @@
+# LiCSBAS2 tests
+
+pytest-based test suite. No network access and no real data are needed;
+everything runs on small synthetic datasets (see `synth.py`) in a few
+tens of seconds.
+
+## Running
+
+```bash
+python -m pip install pytest   # once, into the LiCSBAS conda env
+python -m pytest               # whole suite (~30 s)
+python -m pytest -m "not smoke"  # fast unit tests only (~5 s)
+```
+
+`LiCSBAS_lib` is put on the import path by `pytest.ini`/`conftest.py`,
+so sourcing `bashrc_LiCSBAS.sh` is not required.
+
+## Layout
+
+- `test_tools_lib.py`, `test_inv_lib.py`, `test_loop_lib.py`,
+  `test_io_lib.py`, `test_plot_lib.py` — unit tests of `LiCSBAS_lib`.
+- `test_bin_smoke.py` (marker `smoke`) — runs steps 11–16 and
+  `LiCSBAS_cum2vel.py` as subprocesses on a synthetic 10x10-pixel,
+  5-epoch dataset with a known velocity field, and checks the inverted
+  velocity against the truth.
+- `synth.py` — builder of the synthetic GEOCml-format dataset.
+
+## Known bugs pinned with xfail
+
+Tests marked `xfail(strict=True)` document existing latent bugs (e.g.
+calls to the nonexistent `np.linalg.leastsq` in
+`LiCSBAS_inv_lib.censored_lstsq*`). They are expected to fail until the
+bugs are fixed in separate PRs; when a fix lands, the test starts
+XPASS-ing and must be updated to assert the correct behavior.
+
+## Manual end-to-end tests
+
+`bin/test_LiCSBAS.sh` and `bin/test2_LiCSBAS.sh` (if present) download a
+real LiCSAR frame and run the full batch pipeline. They are
+network-heavy manual tests, intentionally outside pytest.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,108 @@
+"""
+Shared pytest configuration and fixtures for the LiCSBAS test suite.
+
+LiCSBAS is not an installable package; LiCSBAS_lib must be on sys.path
+(normally done by sourcing bashrc_LiCSBAS.sh). pytest.ini sets
+pythonpath = LiCSBAS_lib, and the sys.path insertion below makes the
+tests work even when invoked in ways that bypass pytest.ini.
+"""
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+os.environ.setdefault('MPLBACKEND', 'Agg')
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+REPO = Path(__file__).resolve().parents[1]
+LIB = REPO / 'LiCSBAS_lib'
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+import pytest  # noqa: E402
+
+
+@pytest.fixture(scope='session')
+def repo_root():
+    return REPO
+
+
+@pytest.fixture(scope='session')
+def bin_env():
+    """Environment for running bin/ scripts as subprocesses."""
+    env = os.environ.copy()
+    env['PYTHONPATH'] = str(LIB) + os.pathsep + env.get('PYTHONPATH', '')
+    env['MPLBACKEND'] = 'Agg'
+    env['QT_QPA_PLATFORM'] = 'offscreen'
+    return env
+
+
+@pytest.fixture(scope='session')
+def run_script(bin_env):
+    """Run bin/<script> with args in cwd and assert exit code 0."""
+    def run(script, *args, cwd):
+        cmd = [sys.executable, str(REPO / 'bin' / script)] + [str(a) for a in args]
+        res = subprocess.run(cmd, env=bin_env, cwd=str(cwd),
+                             capture_output=True, text=True, timeout=300)
+        assert res.returncode == 0, (
+            '{} failed with code {}\n--- stdout ---\n{}\n--- stderr ---\n{}'
+            .format(script, res.returncode, res.stdout, res.stderr))
+        return res
+    return run
+
+
+# The synthetic dataset builder lives in tests/synth.py. Import it here so
+# test modules and fixtures can share it regardless of invocation directory.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import synth  # noqa: E402
+
+
+@pytest.fixture(scope='session')
+def geocml(tmp_path_factory):
+    """Build the synthetic GEOCml1 dataset once per session.
+
+    Returns a SimpleNamespace with workdir, geocdir and the truth model
+    (vel_mm, imdates, ifgdates, coef_r2m, ...).
+    """
+    workdir = tmp_path_factory.mktemp('licsbas_smoke')
+    truth = synth.build_geocml(workdir)
+    return truth
+
+
+@pytest.fixture(scope='session')
+def ts11(geocml, run_script):
+    run_script('LiCSBAS11_check_unw.py', '-d', 'GEOCml1', cwd=geocml.workdir)
+    return geocml.workdir / 'TS_GEOCml1'
+
+
+@pytest.fixture(scope='session')
+def ts12(ts11, geocml, run_script):
+    run_script('LiCSBAS12_loop_closure.py', '-d', 'GEOCml1', '--n_para', '1',
+               cwd=geocml.workdir)
+    return ts11
+
+
+@pytest.fixture(scope='session')
+def ts13(ts12, geocml, run_script):
+    run_script('LiCSBAS13_sb_inv.py', '-d', 'GEOCml1', '--n_para', '1',
+               cwd=geocml.workdir)
+    return ts12
+
+
+@pytest.fixture(scope='session')
+def ts14(ts13, geocml, run_script):
+    run_script('LiCSBAS14_vel_std.py', '-t', 'TS_GEOCml1', cwd=geocml.workdir)
+    return ts13
+
+
+@pytest.fixture(scope='session')
+def ts15(ts14, geocml, run_script):
+    run_script('LiCSBAS15_mask_ts.py', '-t', 'TS_GEOCml1', cwd=geocml.workdir)
+    return ts14
+
+
+@pytest.fixture(scope='session')
+def ts16(ts15, geocml, run_script):
+    run_script('LiCSBAS16_filt_ts.py', '-t', 'TS_GEOCml1', '--n_para', '1',
+               cwd=geocml.workdir)
+    return ts15

--- a/tests/synth.py
+++ b/tests/synth.py
@@ -1,0 +1,114 @@
+"""
+Builder of a small synthetic GEOCml-format dataset for testing.
+
+The dataset is 10x10 pixels, geocoded (mli size == dem size), with 5 epochs
+and 7 interferograms whose phases are exactly consistent (zero loop phase)
+and follow a linear-in-time deformation with a known velocity field.
+"""
+import datetime as dt
+from types import SimpleNamespace
+
+import numpy as np
+
+WIDTH = 10
+LENGTH = 10
+RADAR_FREQUENCY = 5405000000.0  # Hz (Sentinel-1 C-band)
+SPEED_OF_LIGHT = 299792458.0  # m/s
+WAVELENGTH = SPEED_OF_LIGHT / RADAR_FREQUENCY  # ~0.0555 m
+COEF_R2M = -WAVELENGTH / 4 / np.pi * 1000  # rad -> mm (LOS)
+
+IMDATES = ['20200101', '20200113', '20200125', '20200206', '20200218']
+IFG_PAIRS = [(0, 1), (1, 2), (2, 3), (3, 4), (0, 2), (1, 3), (2, 4)]
+IFGDATES = sorted('{}_{}'.format(IMDATES[i], IMDATES[j]) for i, j in IFG_PAIRS)
+
+# bperp (m) of each epoch relative to the first
+BPERP = [0.0, 30.0, -55.0, 12.0, 80.0]
+
+
+def vel_truth_mm():
+    """True velocity field (mm/yr), strictly positive everywhere."""
+    x, y = np.meshgrid(np.arange(WIDTH), np.arange(LENGTH))
+    return (5.0 + 20.0 * (x + y) / 18).astype(np.float32)
+
+
+def dt_cum_years():
+    """Years since the first epoch for each epoch."""
+    d0 = dt.datetime.strptime(IMDATES[0], '%Y%m%d')
+    return np.array([(dt.datetime.strptime(imd, '%Y%m%d') - d0).days / 365.25
+                     for imd in IMDATES])
+
+
+def unw_phase(imd1, imd2):
+    """Unwrapped phase (rad, float32) of the pair imd1_imd2."""
+    dt_cum = dt_cum_years()
+    t1 = dt_cum[IMDATES.index(imd1)]
+    t2 = dt_cum[IMDATES.index(imd2)]
+    dmm = vel_truth_mm() * (t2 - t1)
+    return (dmm / COEF_R2M).astype(np.float32)
+
+
+def write_mli_par(path, width=WIDTH, length=LENGTH,
+                  radar_frequency=RADAR_FREQUENCY):
+    with open(path, 'w') as f:
+        print('range_samples:    {}'.format(width), file=f)
+        print('azimuth_lines:    {}'.format(length), file=f)
+        print('radar_frequency:  {} Hz'.format(radar_frequency), file=f)
+
+
+def write_dem_par(path, width=WIDTH, length=LENGTH, corner_lat=34.0,
+                  corner_lon=132.0, post_lat=-0.001, post_lon=0.001):
+    with open(path, 'w') as f:
+        print('width:          {}'.format(width), file=f)
+        print('nlines:         {}'.format(length), file=f)
+        print('corner_lat:     {}  decimal degrees'.format(corner_lat), file=f)
+        print('corner_lon:     {}  decimal degrees'.format(corner_lon), file=f)
+        print('post_lat:       {}  decimal degrees'.format(post_lat), file=f)
+        print('post_lon:       {}  decimal degrees'.format(post_lon), file=f)
+        print('ellipsoid_ra:   6378137.000  m', file=f)
+        print('ellipsoid_reciprocal_flattening:  298.2572236', file=f)
+
+
+def write_img(path, array):
+    """Write an array as little-endian raw binary (GEOCml format)."""
+    array.tofile(str(path))
+
+
+def write_baselines(path, imdates=IMDATES, bperp=BPERP):
+    """Write a baselines file in the new 4-column format."""
+    d0 = dt.datetime.strptime(imdates[0], '%Y%m%d')
+    with open(path, 'w') as f:
+        for imd, bp in zip(imdates[1:], bperp[1:]):
+            days = (dt.datetime.strptime(imd, '%Y%m%d') - d0).days
+            print('{} {} {:6.1f} {:5.1f}'.format(imdates[0], imd, bp,
+                                                 float(days)), file=f)
+
+
+def build_geocml(workdir):
+    """Create workdir/GEOCml1 and return the truth model."""
+    geocdir = workdir / 'GEOCml1'
+    geocdir.mkdir()
+
+    write_mli_par(geocdir / 'slc.mli.par')
+    write_dem_par(geocdir / 'EQA.dem_par')
+    write_baselines(geocdir / 'baselines')
+
+    # Tiny deterministic noise: with exactly zero loop phase, the ref
+    # selection in step 12 masks rms==0 pixels as nodata and fails.
+    # sigma = 0.0003 rad (~0.001 mm) keeps the truth check meaningful.
+    rng = np.random.default_rng(42)
+
+    cc = np.full((LENGTH, WIDTH), 180, dtype=np.uint8)
+    for ifgd in IFGDATES:
+        d = geocdir / ifgd
+        d.mkdir()
+        unw = unw_phase(ifgd[:8], ifgd[-8:]) \
+            + rng.normal(0, 0.0003, (LENGTH, WIDTH)).astype(np.float32)
+        write_img(d / (ifgd + '.unw'), unw)
+        write_img(d / (ifgd + '.cc'), cc)
+        (d / (ifgd + '.unw.png')).touch()  # existence only is checked
+
+    return SimpleNamespace(
+        workdir=workdir, geocdir=geocdir, width=WIDTH, length=LENGTH,
+        imdates=IMDATES, ifgdates=IFGDATES, bperp=BPERP,
+        vel_mm=vel_truth_mm(), dt_cum=dt_cum_years(),
+        wavelength=WAVELENGTH, coef_r2m=COEF_R2M)

--- a/tests/test_bin_smoke.py
+++ b/tests/test_bin_smoke.py
@@ -1,0 +1,143 @@
+"""End-to-end smoke tests of the LiCSBAS time series analysis chain
+(steps 11-16) on a small synthetic dataset.
+
+The step fixtures in conftest.py run each script once per session via
+subprocess; the tests here check their outputs. All data is synthetic
+(tests/synth.py): 10x10 pixels, 5 epochs, 7 exactly loop-consistent
+interferograms of a known linear velocity field, so the inverted
+velocity can be compared against the truth.
+"""
+import re
+
+import h5py
+import numpy as np
+import pytest
+
+import LiCSBAS_io_lib as io_lib
+
+pytestmark = pytest.mark.smoke
+
+
+#%% Step 11: check unw
+def test_step11_outputs(ts11, geocml):
+    infodir = ts11 / 'info'
+    assert (infodir / '11bad_ifg.txt').read_text() == ''
+    stats = (infodir / '11ifg_stats.txt').read_text().splitlines()
+    data_lines = [l for l in stats if re.match(r'^2\d{7}_2\d{7}', l)]
+    assert len(data_lines) == len(geocml.ifgdates)
+    assert (infodir / 'slc.mli.par').exists()
+    assert (infodir / 'EQA.dem_par').exists()
+    network_pngs = list((ts11 / 'network').glob('network11*.png'))
+    assert network_pngs and all(p.stat().st_size > 0 for p in network_pngs)
+
+
+#%% Step 12: loop closure
+def test_step12_outputs(ts12, geocml):
+    infodir = ts12 / 'info'
+    assert (infodir / '12bad_ifg.txt').read_text() == ''
+
+    ref = (infodir / '12ref.txt').read_text().strip()
+    x1, x2, y1, y2 = [int(s) for s in re.split('[:/]', ref)]
+    assert 0 <= x1 < x2 <= geocml.width
+    assert 0 <= y1 < y2 <= geocml.length
+
+    resultsdir = ts12 / 'results'
+    n_unw = io_lib.read_img(str(resultsdir / 'n_unw'),
+                            geocml.length, geocml.width)
+    np.testing.assert_array_equal(n_unw, len(geocml.ifgdates))
+
+    coh_avg = io_lib.read_img(str(resultsdir / 'coh_avg'),
+                              geocml.length, geocml.width)
+    np.testing.assert_allclose(coh_avg, 180 / 255, atol=0.01)
+
+    n_loop_err = io_lib.read_img(str(resultsdir / 'n_loop_err'),
+                                 geocml.length, geocml.width)
+    np.testing.assert_array_equal(n_loop_err, 0)
+
+
+#%% Step 13: small baseline inversion
+def test_step13_cum_h5(ts13, geocml):
+    cumfile = ts13 / 'cum.h5'
+    assert cumfile.exists()
+    with h5py.File(str(cumfile), 'r') as f:
+        cum = f['cum'][()]
+        vel = f['vel'][()]
+        imdates = [str(d) for d in f['imdates'][()]]
+        refarea = f['refarea'][()]
+
+    n_im = len(geocml.imdates)
+    assert cum.shape == (n_im, geocml.length, geocml.width)
+    assert vel.shape == (geocml.length, geocml.width)
+    assert imdates == geocml.imdates
+    assert np.all(np.isfinite(vel))
+
+    # Velocity must match the synthetic truth after subtracting the
+    # reference area (mm/yr)
+    refarea = refarea.decode() if isinstance(refarea, bytes) else str(refarea)
+    x1, x2, y1, y2 = [int(s) for s in re.split('[:/]', refarea)]
+    vel_ref = np.nanmean(vel[y1:y2, x1:x2])
+    truth_ref = np.nanmean(geocml.vel_mm[y1:y2, x1:x2])
+    np.testing.assert_allclose(vel - vel_ref, geocml.vel_mm - truth_ref,
+                               atol=0.1)
+
+    params = (ts13 / 'info' / '13parameters.txt').read_text()
+    assert 'wavelength' in params
+    assert 'pixel_spacing_r' in params
+
+
+def test_step13_ref(ts13):
+    ref = (ts13 / 'info' / '13ref.txt').read_text().strip()
+    assert re.match(r'^\d+:\d+/\d+:\d+$', ref)
+
+
+#%% Step 14: velocity std
+def test_step14_outputs(ts14, geocml):
+    resultsdir = ts14 / 'results'
+    vstd = io_lib.read_img(str(resultsdir / 'vstd'),
+                           geocml.length, geocml.width)
+    assert np.all(np.isfinite(vstd))
+    assert np.all(vstd < 1)  # exact linear data -> tiny bootstrap std
+
+    stc = io_lib.read_img(str(resultsdir / 'stc'),
+                          geocml.length, geocml.width)
+    assert np.all(np.isfinite(stc))
+    assert np.all(stc < 1)  # exact linear data -> tiny stc
+
+
+#%% Step 15: mask
+def test_step15_outputs(ts15, geocml):
+    resultsdir = ts15 / 'results'
+    mask = io_lib.read_img(str(resultsdir / 'mask'),
+                           geocml.length, geocml.width)
+    assert set(np.unique(mask)) <= {0.0, 1.0}
+    assert np.any(mask == 1)
+
+    vel_mskd = io_lib.read_img(str(resultsdir / 'vel.mskd'),
+                               geocml.length, geocml.width)
+    assert np.any(np.isfinite(vel_mskd))
+
+
+#%% Step 16: filter
+def test_step16_outputs(ts16, geocml):
+    cumffile = ts16 / 'cum_filt.h5'
+    assert cumffile.exists()
+    with h5py.File(str(cumffile), 'r') as f:
+        cum_filt = f['cum'][()]
+    n_im = len(geocml.imdates)
+    assert cum_filt.shape == (n_im, geocml.length, geocml.width)
+
+    vel_filt = io_lib.read_img(str(ts16 / 'results' / 'vel.filt'),
+                               geocml.length, geocml.width)
+    assert np.all(np.isfinite(vel_filt))
+    assert (ts16 / 'info' / '16parameters.txt').exists()
+
+
+#%% Downstream tool: cum2vel
+def test_cum2vel(ts13, geocml, run_script):
+    run_script('LiCSBAS_cum2vel.py', '-i', 'TS_GEOCml1/cum.h5',
+               '-o', 'vel.cum2vel', cwd=geocml.workdir)
+    with h5py.File(str(ts13 / 'cum.h5'), 'r') as f:
+        vel_h5 = f['vel'][()]
+    vel_out = io_lib.read_img(str(geocml.workdir / 'vel.cum2vel'),
+                              geocml.length, geocml.width)
+    np.testing.assert_allclose(vel_out, vel_h5, atol=0.01)

--- a/tests/test_inv_lib.py
+++ b/tests/test_inv_lib.py
@@ -1,0 +1,212 @@
+"""Unit tests for LiCSBAS_inv_lib (SBAS design matrices and inversion)."""
+import numpy as np
+import pytest
+
+import LiCSBAS_inv_lib as inv_lib
+import synth
+
+
+IFGDATES = synth.IFGDATES  # 5 epochs, 7 ifgs (4 consecutive + 3 skip-1)
+N_IM = len(synth.IMDATES)
+N_IFG = len(IFGDATES)
+DT_CUM = synth.dt_cum_years()
+
+
+def forward_model_unw(vel, n_pt):
+    """unw (n_pt, n_ifg) for point velocities vel (n_pt,) [unit/yr]."""
+    G = inv_lib.make_sb_matrix(IFGDATES)
+    inc_true = vel[:, None] * np.diff(DT_CUM)[None, :]  # (n_pt, n_im-1)
+    return inc_true @ G.T.astype(np.float64), inc_true
+
+
+#%% Design matrices
+def test_make_sb_matrix():
+    G = inv_lib.make_sb_matrix(IFGDATES)
+    assert G.shape == (N_IFG, N_IM - 1)
+    for i, ifgd in enumerate(IFGDATES):
+        ix_p = synth.IMDATES.index(ifgd[:8])
+        ix_s = synth.IMDATES.index(ifgd[-8:])
+        expected = np.zeros(N_IM - 1)
+        expected[ix_p:ix_s] = 1
+        np.testing.assert_array_equal(G[i], expected)
+
+
+def test_make_sb_matrix2():
+    A = inv_lib.make_sb_matrix2(IFGDATES)
+    assert A.shape == (N_IFG, N_IM)
+    assert np.all(A.sum(axis=1) == 0)  # one -1 and one +1 per row
+    assert np.all((A == -1).sum(axis=1) == 1)
+    assert np.all((A == 1).sum(axis=1) == 1)
+
+
+#%% Velocity estimation
+def test_calc_vel_exact_linear():
+    vel_true = np.array([0.0, 5.0, -3.0, 12.5])
+    vconst_true = np.array([1.0, 0.0, -2.0, 4.0])
+    cum = (vconst_true[:, None] + vel_true[:, None] * DT_CUM[None, :]
+           ).astype(np.float32)
+    vel, vconst = inv_lib.calc_vel(cum, DT_CUM)
+    np.testing.assert_allclose(vel, vel_true, atol=1e-4)
+    np.testing.assert_allclose(vconst, vconst_true, atol=1e-4)
+
+
+def test_calc_vel_with_nan():
+    vel_true = np.array([5.0, -3.0])
+    cum = (vel_true[:, None] * DT_CUM[None, :]).astype(np.float32)
+    cum[0, 2] = np.nan
+    vel, vconst = inv_lib.calc_vel(cum, DT_CUM)
+    np.testing.assert_allclose(vel, vel_true, atol=1e-4)
+
+
+def test_calc_velsin_recovers_sine():
+    # 3 years of 12-day sampling for a stable sin fit
+    import datetime as dtmod
+    imd0 = '20200101'
+    days = np.arange(0, 3 * 365, 12)
+    dt_cum = days / 365.25
+    vel_true, amp_true = 4.0, 6.0
+    delta_t_true = 100.0  # day of year of the sine peak offset
+    phi = 2 * np.pi * (-delta_t_true) / 365.25
+    cum = (vel_true * dt_cum
+           + amp_true * np.sin(2 * np.pi * dt_cum + phi)
+           ).astype(np.float32)[None, :]
+    vel, vconst, amp, delta_t = inv_lib.calc_velsin(cum, dt_cum, imd0)
+    np.testing.assert_allclose(vel[0], vel_true, atol=0.05)
+    np.testing.assert_allclose(amp[0], amp_true, atol=0.05)
+    np.testing.assert_allclose(delta_t[0], delta_t_true, atol=2)
+
+
+#%% STC
+def test_calc_stc_finite_for_smooth_field():
+    rng = np.random.default_rng(1)
+    cum = rng.normal(size=(4, 5, 5)).astype(np.float32)
+    stc = inv_lib.calc_stc(cum)
+    assert stc.shape == (5, 5)
+    assert np.all(np.isfinite(stc))
+    assert np.all(stc > 0)
+
+
+def test_calc_stc_isolated_pixel_nan():
+    rng = np.random.default_rng(1)
+    cum = np.full((4, 5, 5), np.nan, dtype=np.float32)
+    cum[:, 0, 0] = rng.normal(size=4)  # isolated pixel, no valid neighbor
+    stc = inv_lib.calc_stc(cum)
+    assert np.isnan(stc[0, 0])
+
+
+#%% Censored least squares
+def test_censored_lstsq_slow_recovers():
+    rng = np.random.default_rng(2)
+    A = rng.normal(size=(20, 3))
+    X_true = rng.normal(size=(3, 5))
+    B = A @ X_true
+    M = rng.random((20, 5)) > 0.2  # ~20% censored
+    X = inv_lib.censored_lstsq_slow(A, B, M)
+    np.testing.assert_allclose(X, X_true, atol=1e-8)
+
+
+def test_censored_lstsq2_multicolumn():
+    rng = np.random.default_rng(3)
+    A = rng.normal(size=(20, 2))
+    X_true = rng.normal(size=(2, 6))
+    B = A @ X_true
+    M = rng.random((20, 6)) > 0.2
+    inv_lib.bootcount, inv_lib.bootnum = 0, 1  # globals used by a print
+    X = inv_lib.censored_lstsq2(A, B, M)
+    np.testing.assert_allclose(X, X_true, atol=1e-8)
+
+
+@pytest.mark.xfail(raises=AttributeError, strict=True,
+                   reason='np.linalg.leastsq does not exist (should be '
+                          'lstsq); LiCSBAS_inv_lib.py censored_lstsq')
+def test_censored_lstsq_1d_bug():
+    # Documents a latent bug: the 1-D/single-column branch calls the
+    # nonexistent np.linalg.leastsq. Fix in a separate PR.
+    A = np.eye(4)
+    b = np.arange(4.0)
+    m = np.ones(4, dtype=bool)
+    X = inv_lib.censored_lstsq(A, b, m)
+    np.testing.assert_allclose(X, b)
+
+
+@pytest.mark.xfail(raises=AttributeError, strict=True,
+                   reason='np.linalg.leastsq does not exist (should be '
+                          'lstsq); LiCSBAS_inv_lib.py censored_lstsq2')
+def test_censored_lstsq2_single_column_bug():
+    inv_lib.bootcount, inv_lib.bootnum = 0, 1
+    A = np.eye(4)
+    B = np.arange(4.0)[:, None]
+    M = np.ones((4, 1), dtype=bool)
+    X = inv_lib.censored_lstsq2(A, B, M)
+    np.testing.assert_allclose(np.ravel(X), np.arange(4.0))
+
+
+@pytest.mark.xfail(raises=IndexError, strict=True,
+                   reason='B.shape[1] is accessed before the B.ndim check; '
+                          'LiCSBAS_inv_lib.py censored_lstsq2')
+def test_censored_lstsq2_1d_bug():
+    inv_lib.bootcount, inv_lib.bootnum = 0, 1
+    A = np.eye(4)
+    b = np.arange(4.0)
+    m = np.ones(4, dtype=bool)
+    inv_lib.censored_lstsq2(A, b, m)
+
+
+#%% NSBAS inversion
+def test_invert_nsbas_forward_model():
+    rng = np.random.default_rng(4)
+    n_pt = 50
+    vel_true = rng.uniform(-20, 20, n_pt)
+    unw, inc_true = forward_model_unw(vel_true, n_pt)
+    unw = unw.astype(np.float32)
+    # Knock out some observations (keep enough for inversion)
+    unw[rng.random(unw.shape) < 0.1] = np.nan
+    unw[0, :] = np.nan  # one point with all nan
+    G = inv_lib.make_sb_matrix(IFGDATES)
+    inc, vel, vconst = inv_lib.invert_nsbas(unw, G, DT_CUM, 0.0001,
+                                            n_core=1, gpu=False)
+    assert inc.shape == (N_IM - 1, n_pt)
+    np.testing.assert_allclose(vel[1:], vel_true[1:], atol=0.01)
+    np.testing.assert_allclose(inc[:, 1:], inc_true[1:, :].T, atol=0.01)
+
+
+def test_invert_nsbas_ncore2_matches_ncore1():
+    rng = np.random.default_rng(5)
+    n_pt = 30
+    vel_true = rng.uniform(-20, 20, n_pt)
+    unw, _ = forward_model_unw(vel_true, n_pt)
+    unw = unw.astype(np.float32)
+    unw[rng.random(unw.shape) < 0.15] = np.nan  # ensure point-by-point path
+    G = inv_lib.make_sb_matrix(IFGDATES)
+    res1 = inv_lib.invert_nsbas(unw.copy(), G, DT_CUM, 0.0001, 1, False)
+    res2 = inv_lib.invert_nsbas(unw.copy(), G, DT_CUM, 0.0001, 2, False)
+    for a, b in zip(res1, res2):
+        np.testing.assert_allclose(a, b, rtol=1e-6, atol=1e-6)
+
+
+def test_invert_nsbas_wls():
+    rng = np.random.default_rng(6)
+    n_pt = 20
+    vel_true = rng.uniform(-20, 20, n_pt)
+    unw, _ = forward_model_unw(vel_true, n_pt)
+    unw = unw.astype(np.float32)
+    var = np.full_like(unw, 2.0)
+    G = inv_lib.make_sb_matrix(IFGDATES)
+    inc, vel, vconst = inv_lib.invert_nsbas_wls(unw, var, G, DT_CUM,
+                                                0.0001, n_core=1)
+    np.testing.assert_allclose(vel, vel_true, atol=0.01)
+
+
+#%% Bootstrap velocity std (seeded -> deterministic)
+def test_calc_velstd_withnan():
+    rng = np.random.default_rng(7)
+    n_pt, n_im = 4, 20
+    dt_cum = np.arange(n_im) * 12 / 365.25
+    vel_true = np.array([0.0, 10.0, -5.0, 3.0])
+    noise = rng.normal(0, 0.5, (n_pt, n_im))
+    cum = (vel_true[:, None] * dt_cum[None, :] + noise).astype(np.float32)
+    vstd = inv_lib.calc_velstd_withnan(cum, dt_cum)
+    assert vstd.shape == (n_pt,)
+    assert np.all(np.isfinite(vstd))
+    assert np.all(vstd > 0)
+    assert np.all(vstd < 5)  # noise 0.5 -> vstd of order 1 mm/yr

--- a/tests/test_io_lib.py
+++ b/tests/test_io_lib.py
@@ -1,0 +1,220 @@
+"""Unit tests for LiCSBAS_io_lib (file I/O, GAMMA par files, GeoTIFF)."""
+import numpy as np
+import pytest
+
+import LiCSBAS_io_lib as io_lib
+import synth
+
+
+#%% Raw binary images
+def test_read_img_roundtrip_float32(tmp_path):
+    data = np.arange(20, dtype=np.float32).reshape(4, 5)
+    file = tmp_path / 'img.raw'
+    data.tofile(str(file))
+    np.testing.assert_array_equal(io_lib.read_img(str(file), 4, 5), data)
+
+
+def test_read_img_uint8(tmp_path):
+    data = np.arange(20, dtype=np.uint8).reshape(4, 5)
+    file = tmp_path / 'img.raw'
+    data.tofile(str(file))
+    out = io_lib.read_img(str(file), 4, 5, dtype=np.uint8)
+    np.testing.assert_array_equal(out, data)
+
+
+def test_read_img_big_endian(tmp_path):
+    data = np.arange(20, dtype=np.float32).reshape(4, 5)
+    file = tmp_path / 'img.raw'
+    data.astype('>f4').tofile(str(file))
+    out = io_lib.read_img(str(file), 4, 5, endian='big')
+    np.testing.assert_array_equal(out, data)
+
+
+def test_read_img_wrong_size_raises(tmp_path):
+    data = np.arange(20, dtype=np.float32)
+    file = tmp_path / 'img.raw'
+    data.tofile(str(file))
+    with pytest.raises(ValueError):
+        io_lib.read_img(str(file), 4, 4)
+
+
+#%% ifg list
+def test_read_ifg_list(tmp_path):
+    file = tmp_path / 'ifg.txt'
+    file.write_text('# comment line\n'
+                    '20200101_20200113\n'
+                    '20200113_20200125  trailing tokens ignored\n')
+    assert io_lib.read_ifg_list(str(file)) \
+        == ['20200101_20200113', '20200113_20200125']
+
+
+#%% GAMMA par files
+def test_get_param_par(tmp_path):
+    par = tmp_path / 'slc.mli.par'
+    synth.write_mli_par(par, width=123, length=456)
+    assert io_lib.get_param_par(str(par), 'range_samples') == '123'
+    assert io_lib.get_param_par(str(par), 'azimuth_lines') == '456'
+
+
+def test_get_param_par_dem_par(tmp_path):
+    par = tmp_path / 'EQA.dem_par'
+    synth.write_dem_par(par)
+    assert io_lib.get_param_par(str(par), 'corner_lat') == '34.0'
+    assert float(io_lib.get_param_par(str(par), 'post_lat')) == -0.001
+
+
+def test_get_param_par_first_match_wins(tmp_path):
+    # Documents current behavior: grep substring matching returns the
+    # first matching line (relevant e.g. for n_im vs n_im_all).
+    par = tmp_path / 'params.txt'
+    par.write_text('n_im_all: 10\nn_im: 7\n')
+    assert io_lib.get_param_par(str(par), 'n_im') == '10'
+
+
+#%% baselines files
+def test_read_bperp_file_new_format(tmp_path):
+    file = tmp_path / 'baselines'
+    synth.write_baselines(file)
+    bperp = io_lib.read_bperp_file(str(file), synth.IMDATES)
+    np.testing.assert_allclose(bperp, synth.BPERP, atol=0.1)
+
+
+def test_read_bperp_file_old_format(tmp_path):
+    file = tmp_path / 'baselines'
+    imdates = synth.IMDATES
+    with open(file, 'w') as f:
+        # num mdate sdate bp dt dt_m_sm dt_s_sm bp_m_sm bp_s_sm
+        for i, imd in enumerate(imdates[1:], 1):
+            print('{} {} {} {} {} {} {} {} {}'.format(
+                i, imdates[0], imd, synth.BPERP[i], 12*i,
+                0.0, 12.0*i, 0.0, synth.BPERP[i]), file=f)
+    bperp = io_lib.read_bperp_file(str(file), imdates)
+    np.testing.assert_allclose(bperp, synth.BPERP, atol=0.1)
+
+
+def test_read_bperp_file_missing_date(tmp_path, capsys):
+    # Documents current behavior: prints ERROR and returns False
+    file = tmp_path / 'baselines'
+    synth.write_baselines(file)
+    result = io_lib.read_bperp_file(str(file), synth.IMDATES + ['20990101'])
+    assert result is False
+    assert 'ERROR' in capsys.readouterr().err
+
+
+def test_make_bperp_file_roundtrip(tmp_path):
+    file = tmp_path / 'baselines'
+    # dict referenced to an arbitrary common reference; re-referenced to
+    # the first imdate on write
+    bperp_dict = {imd: bp + 100.0
+                  for imd, bp in zip(synth.IMDATES, synth.BPERP)}
+    io_lib.make_bperp_file(str(file), synth.IMDATES, bperp_dict)
+    bperp = io_lib.read_bperp_file(str(file), synth.IMDATES)
+    np.testing.assert_allclose(bperp, synth.BPERP, atol=0.1)
+
+
+def test_make_bperp_file_missing_date_raises(tmp_path):
+    bperp_dict = {imd: 0.0 for imd in synth.IMDATES[:-1]}
+    with pytest.raises(ValueError, match=synth.IMDATES[-1]):
+        io_lib.make_bperp_file(str(tmp_path / 'baselines'),
+                               synth.IMDATES, bperp_dict)
+
+
+def test_make_dummy_bperp(tmp_path):
+    file = tmp_path / 'baselines'
+    io_lib.make_dummy_bperp(str(file), synth.IMDATES)
+    bperp = io_lib.read_bperp_file(str(file), synth.IMDATES)
+    assert len(bperp) == len(synth.IMDATES)
+    assert bperp[0] == 0.0
+    assert np.all(np.abs(bperp) <= 1)  # dummy values are within -1..1
+
+
+#%% Time series text
+def test_make_tstxt(tmp_path):
+    file = tmp_path / 'ts.txt'
+    imdates = synth.IMDATES
+    dt_cum = synth.dt_cum_years()
+    vel_true = 25.0
+    ts = (vel_true * dt_cum).astype(np.float32)
+    gap = np.zeros(len(imdates) - 1)
+    io_lib.make_tstxt(3, 5, imdates, ts, str(file), 1, 2, 3, 4, gap,
+                      lat=34.0, lon=132.0)
+    text = file.read_text()
+    assert '# x, y    : 3, 5' in text
+    assert '# ref     : 1:2/3:4' in text
+    for imd in imdates:
+        assert imd in text
+    # linear model line contains the recovered slope
+    model_line = [l for l in text.splitlines()
+                  if l.startswith('# linear model:')][0]
+    slope = float(model_line.split(':')[1].split('*')[0])
+    assert slope == pytest.approx(vel_true, abs=0.01)
+
+
+def test_make_point_kml(tmp_path):
+    file = tmp_path / 'point.kml'
+    io_lib.make_point_kml(34.5, 132.5, str(file))
+    assert '<coordinates>132.5,34.5</coordinates>' in file.read_text()
+
+
+#%% GeoTIFF (GDAL)
+def test_geotiff_roundtrip(tmp_path):
+    data = np.arange(80, dtype=np.float32).reshape(8, 10)
+    file = tmp_path / 'test.tif'
+    io_lib.make_geotiff(data, 34.0, 132.0, -0.001, 0.001, str(file),
+                        ['COMPRESS=DEFLATE'], nodata=np.nan)
+    out = io_lib.read_geotiff(str(file))
+    np.testing.assert_array_equal(out, data)
+
+    gt, proj, shape = io_lib.get_geotiff_info(str(file))
+    assert shape == (8, 10)
+    np.testing.assert_allclose(gt, (132.0, 0.001, 0, 34.0, 0, -0.001))
+    assert '4326' in proj
+
+
+def test_geotiff_uint8(tmp_path):
+    data = np.arange(80, dtype=np.uint8).reshape(8, 10)
+    file = tmp_path / 'test.tif'
+    io_lib.make_geotiff(data, 34.0, 132.0, -0.001, 0.001, str(file), [])
+    np.testing.assert_array_equal(io_lib.read_geotiff(str(file)), data)
+
+
+@pytest.mark.xfail(raises=UnboundLocalError, strict=True,
+                   reason='make_geotiff has no else branch for dtypes other '
+                          'than float32/uint8; LiCSBAS_io_lib.py')
+def test_make_geotiff_unsupported_dtype_bug(tmp_path):
+    data = np.arange(80, dtype=np.int32).reshape(8, 10)
+    io_lib.make_geotiff(data, 34.0, 132.0, -0.001, 0.001,
+                        str(tmp_path / 'test.tif'), [])
+
+
+def test_read_geotiff_with_ref(tmp_path):
+    data = np.arange(80, dtype=np.float32).reshape(8, 10)
+    file1 = tmp_path / 'a.tif'
+    file2 = tmp_path / 'b.tif'
+    io_lib.make_geotiff(data, 34.0, 132.0, -0.001, 0.001, str(file1), [])
+    io_lib.make_geotiff(data * 2, 34.0, 132.0, -0.001, 0.001, str(file2), [])
+    out = io_lib.read_geotiff(str(file1), file_ref=str(file2))
+    np.testing.assert_array_equal(out, data)
+
+    # Different geometry -> exception
+    file3 = tmp_path / 'c.tif'
+    io_lib.make_geotiff(data, 35.0, 132.0, -0.001, 0.001, str(file3), [])
+    with pytest.raises(Exception, match='not identical'):
+        io_lib.read_geotiff(str(file1), file_ref=str(file3))
+
+
+def test_resample_geotiff(tmp_path):
+    data = np.ones((8, 10), dtype=np.float32) * 7
+    src = tmp_path / 'src.tif'
+    dst = tmp_path / 'dst.tif'
+    io_lib.make_geotiff(data, 34.0, 132.0, -0.001, 0.001, str(src), [])
+    gt, proj, _ = io_lib.get_geotiff_info(str(src))
+    new_gt = (132.0, 0.002, 0, 34.0, 0, -0.002)
+    ok = io_lib.resample_geotiff(str(src), str(dst), new_gt, (4, 5), proj,
+                                 resample_alg='near')
+    assert ok is True
+    out_gt, _, out_shape = io_lib.get_geotiff_info(str(dst))
+    assert out_shape == (4, 5)
+    np.testing.assert_allclose(out_gt, new_gt)
+    np.testing.assert_array_equal(io_lib.read_geotiff(str(dst)),
+                                  np.ones((4, 5), dtype=np.float32) * 7)

--- a/tests/test_loop_lib.py
+++ b/tests/test_loop_lib.py
@@ -1,0 +1,97 @@
+"""Unit tests for LiCSBAS_loop_lib (loop closure)."""
+import numpy as np
+
+import LiCSBAS_loop_lib as loop_lib
+import synth
+
+
+def test_make_loop_matrix_triangle():
+    ifgdates = ['20200101_20200113', '20200113_20200125',
+                '20200101_20200125']
+    Aloop = loop_lib.make_loop_matrix(ifgdates)
+    np.testing.assert_array_equal(Aloop, [[1, 1, -1]])
+
+
+def test_make_loop_matrix_no_loop():
+    ifgdates = ['20200101_20200113', '20200113_20200125']
+    Aloop = loop_lib.make_loop_matrix(ifgdates)
+    assert len(Aloop) == 0
+
+
+def test_make_loop_matrix_network():
+    Aloop = loop_lib.make_loop_matrix(synth.IFGDATES)
+    # 5 epochs, 4 consecutive + 3 skip-1 ifgs -> 3+3=6 triplet loops:
+    # (i,i+1,i+2) via skip ifg for i=0..2, each counted once, plus
+    # loops with the skip ifgs as legs
+    assert Aloop.shape[1] == len(synth.IFGDATES)
+    assert len(Aloop) >= 3
+    assert np.all((Aloop == 1).sum(axis=1) == 2)
+    assert np.all((Aloop == -1).sum(axis=1) == 1)
+
+    # A consistent phase field must close every loop exactly
+    phase = np.array([synth.unw_phase(ifgd[:8], ifgd[-8:])[5, 5]
+                      for ifgd in synth.IFGDATES])
+    np.testing.assert_allclose(Aloop @ phase, 0, atol=1e-5)
+
+
+def test_identify_bad_ifg():
+    bad_cand = ['b', 'a', 'c', 'a']
+    good = ['b']
+    assert loop_lib.identify_bad_ifg(bad_cand, good) == ['a', 'c']
+
+
+def test_read_unw_loop_ph(tmp_path):
+    ifgdates = ['20200101_20200113', '20200113_20200125',
+                '20200101_20200125']
+    length = width = 10
+    for ifgd in ifgdates:
+        d = tmp_path / ifgd
+        d.mkdir()
+        synth.write_img(d / (ifgd + '.unw'),
+                        synth.unw_phase(ifgd[:8], ifgd[-8:]))
+
+    Aloop = loop_lib.make_loop_matrix(ifgdates)
+    unw12, unw23, unw13, ifgd12, ifgd23, ifgd13 = loop_lib.read_unw_loop_ph(
+        Aloop[0], ifgdates, str(tmp_path), length, width)
+
+    assert (ifgd12, ifgd23, ifgd13) == tuple(ifgdates)
+    loop_ph = unw12 + unw23 - unw13
+    np.testing.assert_allclose(loop_ph, 0, atol=1e-5)
+
+
+def test_read_unw_loop_ph_with_error(tmp_path):
+    ifgdates = ['20200101_20200113', '20200113_20200125',
+                '20200101_20200125']
+    length = width = 10
+    for ifgd in ifgdates:
+        d = tmp_path / ifgd
+        d.mkdir()
+        unw = synth.unw_phase(ifgd[:8], ifgd[-8:])
+        if ifgd == '20200113_20200125':
+            unw = unw + 2 * np.pi  # simulated unwrapping error
+        synth.write_img(d / (ifgd + '.unw'), unw)
+
+    Aloop = loop_lib.make_loop_matrix(ifgdates)
+    unw12, unw23, unw13, *_ = loop_lib.read_unw_loop_ph(
+        Aloop[0], ifgdates, str(tmp_path), length, width)
+    loop_ph = unw12 + unw23 - unw13
+    np.testing.assert_allclose(loop_ph, 2 * np.pi, atol=1e-5)
+
+
+def test_read_unw_loop_ph_zero_to_nan(tmp_path):
+    # 0 in unw files is interpreted as nodata -> nan
+    ifgdates = ['20200101_20200113', '20200113_20200125',
+                '20200101_20200125']
+    length = width = 5
+    for ifgd in ifgdates:
+        d = tmp_path / ifgd
+        d.mkdir()
+        unw = np.ones((length, width), dtype=np.float32)
+        unw[0, 0] = 0
+        synth.write_img(d / (ifgd + '.unw'), unw)
+
+    Aloop = loop_lib.make_loop_matrix(ifgdates)
+    unw12, *_ = loop_lib.read_unw_loop_ph(
+        Aloop[0], ifgdates, str(tmp_path), length, width)
+    assert np.isnan(unw12[0, 0])
+    assert unw12[1, 1] == 1

--- a/tests/test_plot_lib.py
+++ b/tests/test_plot_lib.py
@@ -1,0 +1,97 @@
+"""Smoke tests for LiCSBAS_plot_lib (and loop_lib.make_loop_png).
+
+These only assert that a non-empty output file is produced; pixel
+content is not compared.
+"""
+import numpy as np
+import pytest
+
+import LiCSBAS_plot_lib as plot_lib
+import LiCSBAS_loop_lib as loop_lib
+import synth
+
+
+def _assert_png(path):
+    assert path.exists() and path.stat().st_size > 0
+
+
+def test_make_im_png(tmp_path):
+    data = np.arange(100, dtype=np.float32).reshape(10, 10)
+    png = tmp_path / 'im.png'
+    plot_lib.make_im_png(data, str(png), 'viridis', 'title')
+    _assert_png(png)
+
+    # Documents current behavior: float32 input is mutated in place
+    # (0 replaced by nan in the caller's array)
+    assert np.isnan(data[0, 0])
+    assert data[0, 1] == 1
+
+
+def test_make_im_png_insar_cmap(tmp_path):
+    data = np.random.default_rng(0).uniform(
+        -np.pi, np.pi, (10, 10)).astype(np.float32)
+    png = tmp_path / 'im_insar.png'
+    plot_lib.make_im_png(data, str(png), 'insar', 'wrapped',
+                         vmin=-np.pi, vmax=np.pi)
+    _assert_png(png)
+
+
+def test_make_3im_png(tmp_path):
+    data3 = [np.ones((10, 10), dtype=np.float32) * i for i in range(1, 4)]
+    png = tmp_path / '3im.png'
+    plot_lib.make_3im_png(data3, str(png), 'viridis', ['a', 'b', 'c'])
+    _assert_png(png)
+
+    # Documents current behavior: the input list entries are emptied
+    # to free memory, so callers cannot reuse them
+    assert all(d == [] for d in data3)
+
+
+def test_plot_network(tmp_path):
+    png = tmp_path / 'network.png'
+    plot_lib.plot_network(synth.IFGDATES, synth.BPERP, [], str(png))
+    _assert_png(png)
+
+
+def test_plot_network_with_removed(tmp_path):
+    png = tmp_path / 'network_rm.png'
+    plot_lib.plot_network(synth.IFGDATES, synth.BPERP,
+                          [synth.IFGDATES[0]], str(png))
+    _assert_png(png)
+
+
+def test_plot_hgt_corr(tmp_path):
+    rng = np.random.default_rng(1)
+    n = 200
+    hgt = rng.uniform(0, 1000, n).astype(np.float32)
+    fit_hgt = (0.01 * hgt).astype(np.float32)
+    data_bf = fit_hgt + rng.normal(0, 1, n).astype(np.float32)
+    data_bf[5] = np.nan
+    png = tmp_path / 'hgt_corr.png'
+    plot_lib.plot_hgt_corr(data_bf, fit_hgt, hgt, 'test', str(png))
+    _assert_png(png)
+
+
+def test_plot_gacos_info(tmp_path):
+    info = tmp_path / 'gacos_info.txt'
+    info.write_text(
+        'date       std_bf std_af rate\n'
+        '20200101   2.5    1.2    52.0%\n'
+        '20200113   3.1    1.5    51.6%\n'
+        '20200125   0.0    0.0    0.0%\n'   # skipped
+        '20200206   nan    nan    nan%\n'   # skipped
+        '20200218   1.8    2.0    -11.1%\n')
+    png = tmp_path / 'gacos_info.png'
+    plot_lib.plot_gacos_info(str(info), str(png))
+    _assert_png(png)
+
+
+def test_make_loop_png(tmp_path):
+    unw12 = synth.unw_phase('20200101', '20200113')
+    unw23 = synth.unw_phase('20200113', '20200125')
+    unw13 = synth.unw_phase('20200101', '20200125')
+    loop_ph = unw12 + unw23 - unw13
+    png = tmp_path / 'loop.png'
+    loop_lib.make_loop_png(unw12, unw23, unw13, loop_ph, str(png),
+                           ['12', '23', '13', 'loop'], 3)
+    _assert_png(png)

--- a/tests/test_tools_lib.py
+++ b/tests/test_tools_lib.py
@@ -1,0 +1,213 @@
+"""Unit tests for LiCSBAS_tools_lib."""
+import numpy as np
+import pytest
+
+import LiCSBAS_tools_lib as tools_lib
+
+
+# Geometry used in several tests (grid registration, north-up)
+LAT1, POSTLAT = 34.0, -0.001
+LON1, POSTLON = 132.0, 0.001
+WIDTH, LENGTH = 10, 10
+
+
+#%% Coordinate conversions
+def test_bl2xy_corner():
+    assert tools_lib.bl2xy(LON1, LAT1, WIDTH, LENGTH,
+                           LAT1, POSTLAT, LON1, POSTLON) == [0, 0]
+
+
+def test_bl2xy_xy2bl_roundtrip():
+    x, y = 7, 3
+    lat, lon = tools_lib.xy2bl(x, y, LAT1, POSTLAT, LON1, POSTLON)
+    assert tools_lib.bl2xy(lon, lat, WIDTH, LENGTH,
+                           LAT1, POSTLAT, LON1, POSTLON) == [x, y]
+
+
+def test_read_range_geo():
+    # Full-extent bbox covers the whole image
+    lat2 = LAT1 + POSTLAT * (LENGTH - 1)
+    lon2 = LON1 + POSTLON * (WIDTH - 1)
+    range_str = '{}/{}/{}/{}'.format(LON1, lon2, lat2, LAT1)
+    assert tools_lib.read_range_geo(range_str, WIDTH, LENGTH,
+                                    LAT1, POSTLAT, LON1, POSTLON) \
+        == [0, WIDTH, 0, LENGTH]
+
+    # Interior bbox: x2/y2 are exclusive-style (+1)
+    lon_w, lon_e = tools_lib.xy2bl(2, 0, LAT1, POSTLAT, LON1, POSTLON)[1], \
+        tools_lib.xy2bl(5, 0, LAT1, POSTLAT, LON1, POSTLON)[1]
+    lat_n = tools_lib.xy2bl(0, 3, LAT1, POSTLAT, LON1, POSTLON)[0]
+    lat_s = tools_lib.xy2bl(0, 6, LAT1, POSTLAT, LON1, POSTLON)[0]
+    range_str = '{}/{}/{}/{}'.format(lon_w, lon_e, lat_s, lat_n)
+    assert tools_lib.read_range_geo(range_str, WIDTH, LENGTH,
+                                    LAT1, POSTLAT, LON1, POSTLON) \
+        == [2, 6, 3, 7]
+
+
+#%% String parsers
+def test_read_point():
+    assert tools_lib.read_point('3/5', WIDTH, LENGTH) == [3, 5]
+    assert tools_lib.read_point('10/5', WIDTH, LENGTH) is False  # out of range
+    assert tools_lib.read_point('bad', WIDTH, LENGTH) is False
+
+
+def test_read_range():
+    assert tools_lib.read_range('2:5/3:8', WIDTH, LENGTH) == [2, 5, 3, 8]
+    # 0 for x2/y2 means to the edge
+    assert tools_lib.read_range('2:0/3:0', WIDTH, LENGTH) == [2, WIDTH, 3, LENGTH]
+    assert tools_lib.read_range('5:2/3:8', WIDTH, LENGTH) is False  # x1 >= x2
+    assert tools_lib.read_range('2:11/3:8', WIDTH, LENGTH) is False  # exceeds
+    assert tools_lib.read_range('bad', WIDTH, LENGTH) is False
+
+
+def test_read_range_line():
+    # Input is x1,y1/x2,y2 but return is [x1, x2, y1, y2]
+    assert tools_lib.read_range_line('1,2/8,9', WIDTH, LENGTH) == [1, 8, 2, 9]
+    assert tools_lib.read_range_line('1,2/8,10', WIDTH, LENGTH) is False
+
+
+def test_ifgdates2imdates():
+    ifgdates = ['20200113_20200125', '20200101_20200113', '20200101_20200125']
+    assert tools_lib.ifgdates2imdates(ifgdates) \
+        == ['20200101', '20200113', '20200125']
+
+
+def test_get_ifgdates(tmp_path):
+    for d in ['20200101_20200113', '20200113_20200125']:
+        (tmp_path / d).mkdir()
+    (tmp_path / '20200101_20200113.txt').touch()  # file, not dir
+    (tmp_path / 'not_a_pair_dir').mkdir()
+    (tmp_path / '19990101_19990113').mkdir()  # not starting with 2
+    assert tools_lib.get_ifgdates(str(tmp_path)) \
+        == ['20200101_20200113', '20200113_20200125']
+
+
+def test_get_pair_folders(tmp_path):
+    for d in ['20200113_20200125', '20200101_20200113']:
+        (tmp_path / d).mkdir()
+    (tmp_path / 'network').mkdir()
+    assert tools_lib.get_pair_folders(str(tmp_path)) \
+        == ['20200101_20200113', '20200113_20200125']
+
+
+#%% Numeric utilities
+def test_multilook_mean():
+    array = np.arange(16, dtype=np.float32).reshape(4, 4)
+    ml = tools_lib.multilook(array, 2, 2)
+    expected = np.array([[2.5, 4.5], [10.5, 12.5]])
+    np.testing.assert_allclose(ml, expected)
+
+
+def test_multilook_nan_threshold():
+    array = np.arange(16, dtype=np.float32).reshape(4, 4)
+    array[0, 0] = array[0, 1] = array[1, 0] = np.nan  # 3/4 invalid in block
+    ml = tools_lib.multilook(array, 2, 2, n_valid_thre=0.5)
+    assert np.isnan(ml[0, 0])
+    assert not np.isnan(ml[0, 1])
+    # With a lower threshold the single valid pixel is kept
+    ml2 = tools_lib.multilook(array, 2, 2, n_valid_thre=0.25)
+    assert ml2[0, 0] == 5.0
+
+
+def test_get_patchrow():
+    width, length = 100, 1000
+    n_data, memory_size = 100, 10  # 100*1000*100*4B = ~38 MiB -> 4 patches
+    n_patch, patchrow = tools_lib.get_patchrow(width, length, n_data,
+                                               memory_size)
+    assert n_patch == len(patchrow)
+    assert patchrow[0][0] == 0
+    assert patchrow[-1][-1] == length
+    for (a, b), (c, d) in zip(patchrow[:-1], patchrow[1:]):
+        assert b == c  # contiguous
+
+
+def test_convert_size():
+    assert tools_lib.convert_size(0) == '0B'
+    assert tools_lib.convert_size(1024) == '1.0KB'
+    assert tools_lib.convert_size(1536) == '1.5KB'
+    assert tools_lib.convert_size(5 * 1024**3) == '5.0GB'
+
+
+#%% calculate_common_geometry
+def test_calculate_common_geometry_overlap():
+    gt1 = (132.0, 0.001, 0, 34.0, 0, -0.001)
+    gt2 = (132.005, 0.001, 0, 33.995, 0, -0.001)
+    new_gt, (ny, nx) = tools_lib.calculate_common_geometry(
+        gt1, (10, 10), gt2, (10, 10))
+    assert new_gt == (132.005, 0.001, 0, 33.995, 0, -0.001)
+    assert (ny, nx) == (5, 5)
+
+
+def test_calculate_common_geometry_no_overlap():
+    gt1 = (132.0, 0.001, 0, 34.0, 0, -0.001)
+    gt2 = (133.0, 0.001, 0, 34.0, 0, -0.001)
+    with pytest.raises(ValueError):
+        tools_lib.calculate_common_geometry(gt1, (10, 10), gt2, (10, 10))
+
+
+#%% 2D fitting
+def test_fit2d_exact_plane():
+    a, b, c = 3.0, 0.5, -0.25
+    X, Y = np.meshgrid(np.arange(20), np.arange(15))
+    A = (a + b * X + c * Y).astype(np.float32)
+    Afit, m = tools_lib.fit2d(A, deg='1')
+    np.testing.assert_allclose(Afit, A, atol=1e-3)
+    np.testing.assert_allclose(m, [a, b, c], atol=1e-5)
+
+
+def test_fit2d_with_nan():
+    a, b, c = 3.0, 0.5, -0.25
+    X, Y = np.meshgrid(np.arange(20), np.arange(15))
+    A = (a + b * X + c * Y).astype(np.float32)
+    A[3, 4] = A[10, 10] = np.nan
+    Afit, m = tools_lib.fit2d(A, deg='1')
+    np.testing.assert_allclose(m, [a, b, c], atol=1e-4)
+    assert not np.any(np.isnan(Afit))  # fit fills the nan holes
+
+
+@pytest.mark.parametrize('deg, n_param', [('1', 3), ('bl', 4), ('2', 6)])
+def test_fit2d_degrees(deg, n_param):
+    X, Y = np.meshgrid(np.arange(20), np.arange(15))
+    A = (1.0 + 0.1 * X - 0.2 * Y + 0.01 * X * Y).astype(np.float32)
+    Afit, m = tools_lib.fit2d(A, deg=deg)
+    assert len(m) == n_param
+    if deg != '1':  # bilinear term only representable for bl and 2
+        np.testing.assert_allclose(Afit, A, atol=1e-3)
+
+
+def test_fit2d_bad_deg_returns_false():
+    # Documents current behavior: a bare False is returned (not a tuple),
+    # so callers that unpack two values raise TypeError. A future fix
+    # should probably raise instead.
+    A = np.ones((5, 5), dtype=np.float32)
+    assert tools_lib.fit2d(A, deg='7') is False
+
+
+def test_fit2dh_recovers_hgt_coefficient():
+    k = 0.05
+    X, Y = np.meshgrid(np.arange(20), np.arange(15))
+    hgt = (np.random.default_rng(0).integers(0, 1000, (15, 20))
+           ).astype(np.float32)
+    A = (2.0 + 0.1 * X - 0.2 * Y + k * hgt).astype(np.float32)
+    Afit, m = tools_lib.fit2dh(A, '1', hgt, -100, 10000)
+    np.testing.assert_allclose(m[-1], k, atol=1e-6)
+    np.testing.assert_allclose(Afit, A, atol=1e-3)
+
+
+#%% Colormaps
+@pytest.mark.parametrize('name', ['viridis', 'SCM.roma', 'GMT.polar',
+                                  'cm_insar', 'cm_insar_r', 'cm_isce'])
+def test_get_cmap(name):
+    cmap = tools_lib.get_cmap(name, 256)
+    assert cmap.N == 256
+    rgba = cmap(np.linspace(0, 1, 256))
+    assert rgba.shape == (256, 4)
+    assert np.all((rgba >= 0) & (rgba <= 1))
+
+
+def test_cmap_insar_cdict():
+    cdict = tools_lib.cmap_insar()
+    assert set(cdict.keys()) == {'red', 'green', 'blue'}
+    for tup in cdict.values():
+        assert tup[0][0] == 0.0
+        assert tup[-1][0] == 1.0


### PR DESCRIPTION
## Summary

LiCSBAS2 had no automated tests. This PR adds a pytest-based test suite and a GitHub Actions CI workflow. The whole suite needs no network and no real data, and runs in ~30 s (~5 s without the `smoke` marker).

- **Unit tests for all `LiCSBAS_lib` modules** (`tools`, `inv`, `loop`, `io`, `plot`): coordinate conversions, SBAS design matrices, NSBAS inversion (recovering a forward-modeled velocity field, incl. an `n_core=2` vs `n_core=1` consistency check), loop closure, raw-binary/GAMMA-par/baselines I/O, GeoTIFF round-trips, and plot smoke tests.
- **End-to-end smoke tests** (`tests/test_bin_smoke.py`, marker `smoke`): steps 11–16 and `LiCSBAS_cum2vel.py` run as subprocesses on a synthetic 10x10-px, 5-epoch, 7-ifg GEOCml dataset (`tests/synth.py`) with exactly loop-consistent phases from a known velocity field. The inverted velocity is checked against the truth within 0.1 mm/yr.
- **Known latent bugs are pinned with `xfail(strict=True)`**, to be fixed in separate PRs:
  - `inv_lib.censored_lstsq` / `censored_lstsq2` call the nonexistent `np.linalg.leastsq` in their 1-D/single-column branch
  - `censored_lstsq2` accesses `B.shape[1]` before the `B.ndim` check (IndexError for 1-D input)
  - `io_lib.make_geotiff` raises `UnboundLocalError` for dtypes other than float32/uint8
- **CI**: micromamba with a CI-only conda-forge env file (`.github/workflows/environment-ci.yml`; `LiCSBAS.yml` is untouched), triggered on pushes and PRs to master, with environment caching.

Notes:
- The synthetic dataset adds tiny deterministic noise (sigma = 0.0003 rad, seed 42) because step 12's reference selection treats exactly-zero loop-phase RMS as nodata — a situation that cannot occur with real data.
- No packaging changes; `LiCSBAS_lib` is put on the import path by `pytest.ini`/`conftest.py`, so tests run without sourcing `bashrc_LiCSBAS.sh`.

## Test plan

- [x] `python -m pytest` in the licsbas conda env: 85 passed, 4 xfailed in ~30 s
- [x] Same result with `PYTHONPATH`/`MPLBACKEND` unset (self-contained config)
- [ ] CI job on this PR solves the conda-forge env and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)