### PR TITLE
Fix latent bugs pinned with xfail in the test suite

### DIFF
--- a/LiCSBAS_lib/LiCSBAS_inv_lib.py
+++ b/LiCSBAS_lib/LiCSBAS_inv_lib.py
@@ -389,12 +389,13 @@ def censored_lstsq2(A, B, M, gpu=False):
         xp = np
 
     print('\r  Running {0:3}/{1:3}th bootstrap...'.format(bootcount, bootnum), end='', flush=True)
-    Bshape1 = B.shape[1]
+    Bshape1 = 1 if B.ndim == 1 else B.shape[1]
     bootcount = bootcount+1
 
     # if B is a vector, simply drop out corresponding rows in A
     if B.ndim == 1 or Bshape1 == 1:
-        sol = xp.linalg.leastsq(A[M], B[M])[0]
+        m = xp.ravel(M)
+        sol = xp.linalg.lstsq(A[m], xp.ravel(B)[m], rcond=None)[0]
         if gpu:
             sol = xp.asnumpy(sol)
             del A, B, M
@@ -476,40 +477,6 @@ def calc_stc(cum, gpu=False):
         del cum, cum1, _stc, d_cum, dd_cum, sumsq_dd_cum, n_dd_cum
 
     return stc
-
-
-#%%
-def censored_lstsq(A, B, M):
-    ## http://alexhwilliams.info/itsneuronalblog/2018/02/26/censored-lstsq/
-    ## This is actually slow because matmul does not use multicore...
-    ## Need multiprocessing.
-    ## Precison is bad widh bad condition, so this is unfortunately useless for NSABS...
-    ## But maybe usable for vstd because its condition is good.
-    """Solves least squares problem subject to missing data.
-
-    Note: uses a broadcasted solve for speed.
-
-    Args
-    ----
-    A (ndarray) : m x r matrix
-    B (ndarray) : m x n matrix
-    M (ndarray) : m x n binary matrix (zeros indicate missing values)
-
-    Returns
-    -------
-    X (ndarray) : r x n matrix that minimizes norm(M*(AX - B))
-    """
-
-    # Note: we should check A is full rank but we won't bother...
-
-    # if B is a vector, simply drop out corresponding rows in A
-    if B.ndim == 1 or B.shape[1] == 1:
-        return np.linalg.leastsq(A[M], B[M])[0]
-
-    # else solve via tensor representation
-    rhs = np.dot(A.T, M * B).T[:,:,None] # n x r x 1 tensor
-    T = np.matmul(A.T[None,:,:], M.T[:,:,None] * A[None,:,:]) # n x r x r tensor
-    return np.squeeze(np.linalg.solve(T, rhs)).T # transpose to get r x n
 
 
 #%%

--- a/LiCSBAS_lib/LiCSBAS_io_lib.py
+++ b/LiCSBAS_lib/LiCSBAS_io_lib.py
@@ -63,6 +63,8 @@ def make_geotiff(data, latn_p, lonw_p, dlat, dlon, outfile, compress_option, nod
         dtype = gdal.GDT_Float32
     elif data.dtype == np.uint8:
         dtype = gdal.GDT_Byte
+    else:
+        raise ValueError('dtype {} is not supported (must be float32 or uint8)'.format(data.dtype))
 
     driver = gdal.GetDriverByName('GTiff')
     outRaster = driver.Create(outfile, width, length, 1, dtype, options=compress_option)

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,8 +27,8 @@ so sourcing `bashrc_LiCSBAS.sh` is not required.
 
 ## Known bugs pinned with xfail
 
-Tests marked `xfail(strict=True)` document existing latent bugs (e.g.
-calls to the nonexistent `np.linalg.leastsq` in
-`LiCSBAS_inv_lib.censored_lstsq*`). They are expected to fail until the
-bugs are fixed in separate PRs; when a fix lands, the test starts
-XPASS-ing and must be updated to assert the correct behavior.
+Latent bugs found while writing tests are pinned with
+`xfail(strict=True)` markers: such a test is expected to fail until the
+bug is fixed in a separate PR; when a fix lands, the test starts
+XPASS-ing and must be updated to assert the correct behavior. There are
+currently no open xfail tests.

--- a/tests/test_inv_lib.py
+++ b/tests/test_inv_lib.py
@@ -1,6 +1,5 @@
 """Unit tests for LiCSBAS_inv_lib (SBAS design matrices and inversion)."""
 import numpy as np
-import pytest
 
 import LiCSBAS_inv_lib as inv_lib
 import synth
@@ -116,23 +115,7 @@ def test_censored_lstsq2_multicolumn():
     np.testing.assert_allclose(X, X_true, atol=1e-8)
 
 
-@pytest.mark.xfail(raises=AttributeError, strict=True,
-                   reason='np.linalg.leastsq does not exist (should be '
-                          'lstsq); LiCSBAS_inv_lib.py censored_lstsq')
-def test_censored_lstsq_1d_bug():
-    # Documents a latent bug: the 1-D/single-column branch calls the
-    # nonexistent np.linalg.leastsq. Fix in a separate PR.
-    A = np.eye(4)
-    b = np.arange(4.0)
-    m = np.ones(4, dtype=bool)
-    X = inv_lib.censored_lstsq(A, b, m)
-    np.testing.assert_allclose(X, b)
-
-
-@pytest.mark.xfail(raises=AttributeError, strict=True,
-                   reason='np.linalg.leastsq does not exist (should be '
-                          'lstsq); LiCSBAS_inv_lib.py censored_lstsq2')
-def test_censored_lstsq2_single_column_bug():
+def test_censored_lstsq2_single_column():
     inv_lib.bootcount, inv_lib.bootnum = 0, 1
     A = np.eye(4)
     B = np.arange(4.0)[:, None]
@@ -141,15 +124,13 @@ def test_censored_lstsq2_single_column_bug():
     np.testing.assert_allclose(np.ravel(X), np.arange(4.0))
 
 
-@pytest.mark.xfail(raises=IndexError, strict=True,
-                   reason='B.shape[1] is accessed before the B.ndim check; '
-                          'LiCSBAS_inv_lib.py censored_lstsq2')
-def test_censored_lstsq2_1d_bug():
+def test_censored_lstsq2_1d():
     inv_lib.bootcount, inv_lib.bootnum = 0, 1
     A = np.eye(4)
     b = np.arange(4.0)
     m = np.ones(4, dtype=bool)
-    inv_lib.censored_lstsq2(A, b, m)
+    X = inv_lib.censored_lstsq2(A, b, m)
+    np.testing.assert_allclose(np.ravel(X), np.arange(4.0))
 
 
 #%% NSBAS inversion

--- a/tests/test_io_lib.py
+++ b/tests/test_io_lib.py
@@ -178,13 +178,11 @@ def test_geotiff_uint8(tmp_path):
     np.testing.assert_array_equal(io_lib.read_geotiff(str(file)), data)
 
 
-@pytest.mark.xfail(raises=UnboundLocalError, strict=True,
-                   reason='make_geotiff has no else branch for dtypes other '
-                          'than float32/uint8; LiCSBAS_io_lib.py')
-def test_make_geotiff_unsupported_dtype_bug(tmp_path):
+def test_make_geotiff_unsupported_dtype(tmp_path):
     data = np.arange(80, dtype=np.int32).reshape(8, 10)
-    io_lib.make_geotiff(data, 34.0, 132.0, -0.001, 0.001,
-                        str(tmp_path / 'test.tif'), [])
+    with pytest.raises(ValueError, match='not supported'):
+        io_lib.make_geotiff(data, 34.0, 132.0, -0.001, 0.001,
+                            str(tmp_path / 'test.tif'), [])
 
 
 def test_read_geotiff_with_ref(tmp_path):


### PR DESCRIPTION
## Summary

Fixes the four latent bugs documented with `xfail(strict=True)` markers in the test suite added in #161, and updates the corresponding tests to assert the correct behavior. None of these code paths are reached by the normal pipeline (vector inputs / unsupported dtypes), so existing behavior is unchanged.

- **Remove unused `censored_lstsq`** (`LiCSBAS_inv_lib.py`): its vector branch called the nonexistent `np.linalg.leastsq`, and the function has no callers in `LiCSBAS_lib` or `bin` (the ones actually used are `censored_lstsq_slow` and `censored_lstsq2`), so it is deleted rather than fixed.
- **`censored_lstsq2`** (`LiCSBAS_inv_lib.py`): fix an IndexError from accessing `B.shape[1]` before the `B.ndim` check, and fix the same nonexistent `leastsq` call in the vector/single-column branch — now uses `xp.linalg.lstsq(..., rcond=None)` with a raveled mask so `(m, 1)` inputs also work. `cupy.linalg.lstsq` has the same signature, so the GPU path is unaffected.
- **`make_geotiff`** (`LiCSBAS_io_lib.py`): dtypes other than float32/uint8 now raise a clear `ValueError` instead of an `UnboundLocalError` from an undefined variable.
- **Tests**: the three remaining xfail tests now assert the correct results; the test for the deleted function is removed, and `tests/README.md` is updated accordingly.

## Test plan

- `python -m pytest` — full suite (88 tests incl. smoke) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)