### PR TITLE
Fix multiprocessing hangs under memory pressure (steps 03/12/13/16)

### DIFF
--- a/LiCSBAS.yml
+++ b/LiCSBAS.yml
@@ -13,3 +13,4 @@ dependencies:
   - requests=2.32.3
   - shapely=2.0.6
   - statsmodels=0.14.4
+  - threadpoolctl=3.5.0

--- a/LiCSBAS_lib/LiCSBAS_inv_lib.py
+++ b/LiCSBAS_lib/LiCSBAS_inv_lib.py
@@ -2,13 +2,12 @@
 """
 Python3 library of time series inversion functions for LiCSBAS.
 
-v1.5.2 20250715 Yu Morishita
+v1.5.3 20260818 Yu Morishita
 """
 
 import warnings
 import numpy as np
 import datetime as dt
-import multiprocessing as multi
 from astropy.stats import bootstrap
 from astropy.utils import NumpyRNGContext
 import LiCSBAS_tools_lib as tools_lib
@@ -128,10 +127,9 @@ def invert_nsbas(unw, G, dt_cum, gamma, n_core, gpu):
     else:
         print('  {} parallel processing'.format(n_core), flush=True)
 
-        args = [i for i in range(n_pt-n_pt_full)]
-        q = multi.get_context('fork')
-        p = q.Pool(n_core)
-        _result = p.map(censored_lstsq_slow_para_wrapper, args) #list[n_pt][length]
+        _result = tools_lib.run_pool(censored_lstsq_slow_para_wrapper,
+                                     range(n_pt-n_pt_full),
+                                     n_core) #list[n_pt][length]
         result[:, ~bool_pt_full] = np.array(_result).T
 
     inc = result[:n_im-1, :]
@@ -201,10 +199,8 @@ def invert_nsbas_wls(unw, var, G, dt_cum, gamma, n_core):
     else:
         print('  {} parallel processing'.format(n_core), flush=True)
 
-        args = [i for i in range(n_pt)]
-        q = multi.get_context('fork')
-        p = q.Pool(n_core)
-        _result = p.map(wls_nsbas, args) #list[n_pt][length]
+        _result = tools_lib.run_pool(wls_nsbas, range(n_pt),
+                                     n_core) #list[n_pt][length]
         result = np.array(_result).T
 
     inc = result[:n_im-1, :]

--- a/LiCSBAS_lib/LiCSBAS_loop_lib.py
+++ b/LiCSBAS_lib/LiCSBAS_loop_lib.py
@@ -58,7 +58,9 @@ def make_loop_matrix(ifgdates):
             Aline[ix_ifg13] = -1
             Aloop.append(Aline)
 
-    Aloop = np.array(Aloop)
+    ## int8 because the values are only 1, -1 and 0. Keeps the temporary
+    ## arrays derived from Aloop small (int64 by default).
+    Aloop = np.array(Aloop, dtype=np.int8)
 
     return Aloop
 

--- a/LiCSBAS_lib/LiCSBAS_tools_lib.py
+++ b/LiCSBAS_lib/LiCSBAS_tools_lib.py
@@ -650,6 +650,20 @@ def get_patchrow(width, length, n_data, memory_size):
 
 
 #%%
+def _limit_worker_threads():
+    ### Initializer for run_pool workers: limit BLAS/OpenMP to 1 thread to
+    ### avoid oversubscription (n_para workers x N BLAS threads). Must run
+    ### in the worker itself because the OpenMP limit is thread-local and
+    ### does not reliably survive fork. Keep a global reference so the
+    ### limit is not undone by garbage collection.
+    global _worker_thread_limit
+    try:
+        from threadpoolctl import threadpool_limits
+        _worker_thread_limit = threadpool_limits(limits=1)
+    except ImportError:  ## Same behavior as before, only risking slowdown
+        pass
+
+
 def run_pool(func, args, n_para, mem_per_worker_mb=None, chunksize=None,
              out=None, store=None):
     """
@@ -665,8 +679,11 @@ def run_pool(func, args, n_para, mem_per_worker_mb=None, chunksize=None,
       (streaming; avoids materializing all results at a time).
     - If store is given, store(i, result) is called instead (e.g., for
       functions returning tuples). store overrides out.
-    - If n_para == 1, run serially without forking (also should be used
-      after GPU use because forking after CUDA initialization is unsafe).
+    - If n_para == 1, run serially without forking.
+    - Each worker limits its BLAS/OpenMP threads to 1 (if threadpoolctl is
+      available) to avoid oversubscription by n_para workers x N BLAS
+      threads. The parent is not affected, so serial BLAS calls in the
+      caller stay multi-threaded.
 
     Returns:
         list of results in the order of args (or out if out is given)
@@ -711,7 +728,8 @@ def run_pool(func, args, n_para, mem_per_worker_mb=None, chunksize=None,
 
     ctx = multi.get_context('fork')
     try:
-        with ProcessPoolExecutor(max_workers=n_para, mp_context=ctx) as p:
+        with ProcessPoolExecutor(max_workers=n_para, mp_context=ctx,
+                                 initializer=_limit_worker_threads) as p:
             return _consume(p.map(func, args, chunksize=chunksize))
     except BrokenProcessPool as e:
         raise RuntimeError(

--- a/LiCSBAS_lib/LiCSBAS_tools_lib.py
+++ b/LiCSBAS_lib/LiCSBAS_tools_lib.py
@@ -686,7 +686,8 @@ def run_pool(func, args, n_para, mem_per_worker_mb=None, chunksize=None,
       caller stay multi-threaded.
 
     Returns:
-        list of results in the order of args (or out if out is given)
+        list of results in the order of args, or out if out is given, or
+        None if store is given (the caller stores the results itself)
     """
     from concurrent.futures import ProcessPoolExecutor
     from concurrent.futures.process import BrokenProcessPool
@@ -733,14 +734,17 @@ def run_pool(func, args, n_para, mem_per_worker_mb=None, chunksize=None,
             return _consume(p.map(func, args, chunksize=chunksize))
     except BrokenProcessPool as e:
         raise RuntimeError(
-            'A worker process died unexpectedly, most likely killed by the '
-            'OS out-of-memory (OOM) killer because memory ran out\n'
-            '(check with e.g. `dmesg -T | grep -i "killed process"`).\n'
-            'Try one of the following and rerun:\n'
+            'A worker process died unexpectedly ({}).\n'
+            'The most common cause is the OS out-of-memory (OOM) killer when '
+            'memory ran out (check with e.g.\n'
+            '`dmesg -T | grep -i "killed process"`), but a crash inside the '
+            'worker itself looks the same here.\n'
+            'If it was memory, try one of the following and rerun:\n'
             '  - Reduce the number of parallel workers (--n_para)\n'
-            '  - Reduce memory use (e.g., --mem_size, smaller data size)\n'
+            '  - Reduce memory use (--mem_size if the script has it, or '
+            'reduce the data size in step02 or step05)\n'
             '  - Close other programs or use a machine with more memory'
-        ) from e
+            .format(type(e).__name__)) from e
 
 
 #%%

--- a/LiCSBAS_lib/LiCSBAS_tools_lib.py
+++ b/LiCSBAS_lib/LiCSBAS_tools_lib.py
@@ -2,7 +2,7 @@
 """
 Python3 library of time series analysis tools for LiCSBAS.
 
-v1.11.0 20260811 Yu Morishita
+v1.12.0 20260818 Yu Morishita
 """
 import os
 import sys
@@ -648,6 +648,81 @@ def get_patchrow(width, length, n_data, memory_size):
 
     return n_patch, patchrow
 
+
+#%%
+def run_pool(func, args, n_para, mem_per_worker_mb=None, chunksize=None,
+             out=None, store=None):
+    """
+    Robust replacement of multiprocessing fork Pool(n_para).map(func, args).
+
+    - Forks workers so that func can use global variables set in the caller
+      (same semantics as the conventional fork Pool in LiCSBAS).
+    - If mem_per_worker_mb is given, n_para is capped just before execution
+      based on the currently available memory to avoid OOM.
+    - If a worker dies unexpectedly (e.g., killed by the OS out-of-memory
+      killer), raise RuntimeError with advice instead of hanging forever.
+    - If out is given, results are stored one by one as out[i] = result
+      (streaming; avoids materializing all results at a time).
+    - If store is given, store(i, result) is called instead (e.g., for
+      functions returning tuples). store overrides out.
+    - If n_para == 1, run serially without forking (also should be used
+      after GPU use because forking after CUDA initialization is unsafe).
+
+    Returns:
+        list of results in the order of args (or out if out is given)
+    """
+    from concurrent.futures import ProcessPoolExecutor
+    from concurrent.futures.process import BrokenProcessPool
+    import multiprocessing as multi
+    import psutil
+
+    args = list(args)
+    n_task = len(args)
+    if n_task == 0:
+        return [] if (out is None and store is None) else out
+    n_para = max(1, min(int(n_para), n_task))
+
+    ### Cap n_para by memory available now
+    if mem_per_worker_mb:
+        mem_avail = psutil.virtual_memory().available / 2**20  # MB
+        n_para_mem = max(1, int(mem_avail / 2 / mem_per_worker_mb))
+        if n_para_mem < n_para:
+            print('  Reduce n_para from {} to {} due to available memory '
+                  '({:.0f} MB, ~{:.0f} MB/worker)'.format(
+                      n_para, n_para_mem, mem_avail, mem_per_worker_mb),
+                  flush=True)
+            n_para = n_para_mem
+
+    if store is None and out is not None:
+        def store(i, r): out[i] = r
+
+    def _consume(iterator):
+        if store is None:
+            return list(iterator)
+        for i, r in enumerate(iterator):
+            store(i, r)
+        return out
+
+    if n_para == 1:  ## Serial, no fork
+        return _consume(map(func, args))
+
+    if chunksize is None:  ## Mimic default of Pool.map
+        chunksize = -(-n_task // (n_para*4))
+
+    ctx = multi.get_context('fork')
+    try:
+        with ProcessPoolExecutor(max_workers=n_para, mp_context=ctx) as p:
+            return _consume(p.map(func, args, chunksize=chunksize))
+    except BrokenProcessPool as e:
+        raise RuntimeError(
+            'A worker process died unexpectedly, most likely killed by the '
+            'OS out-of-memory (OOM) killer because memory ran out\n'
+            '(check with e.g. `dmesg -T | grep -i "killed process"`).\n'
+            'Try one of the following and rerun:\n'
+            '  - Reduce the number of parallel workers (--n_para)\n'
+            '  - Reduce memory use (e.g., --mem_size, smaller data size)\n'
+            '  - Close other programs or use a machine with more memory'
+        ) from e
 
 
 #%%

--- a/bin/LiCSBAS03op_GACOS.py
+++ b/bin/LiCSBAS03op_GACOS.py
@@ -132,7 +132,7 @@ def main(argv=None):
         argv = sys.argv
 
     start = time.time()
-    ver="1.5.7"; date=20250715; author="Y. Morishita"
+    ver="1.5.8"; date=20260818; author="Y. Morishita"
     print("\n{} ver{} {} {}".format(os.path.basename(argv[0]), ver, date, author), flush=True)
     print("{} {}".format(os.path.basename(argv[0]), ' '.join(argv[1:])), flush=True)
 
@@ -153,7 +153,6 @@ def main(argv=None):
     except:
         n_para = multi.cpu_count() - 1
 
-    q = multi.get_context('fork')
     cmap_wrap = tools_lib.get_cmap('cm_insar')
 
     #%% Read options
@@ -277,9 +276,11 @@ def main(argv=None):
             _n_para = n_para
 
         print('  {} parallel processing...'.format(_n_para), flush=True)
-        p = q.Pool(_n_para)
-        no_gacos_imds = p.map(convert_wrapper, range(n_im2))
-        p.close()
+        ### ~8 float32 frames per worker (gdal.Warp MEM, sltd, png)
+        _mem_per_worker_mb = 8*length_geo*width_geo*4/2**20
+        no_gacos_imds = tools_lib.run_pool(convert_wrapper, range(n_im2),
+                                           _n_para,
+                                           mem_per_worker_mb=_mem_per_worker_mb)
 
         for imd in no_gacos_imds:
             if imd is not None:
@@ -319,9 +320,11 @@ def main(argv=None):
             _n_para = n_para
 
         print('  {} parallel processing...'.format(_n_para), flush=True)
-        p = q.Pool(_n_para)
-        _return = p.map(correct_wrapper, range(n_ifg2))
-        p.close()
+        ### ~8 float32 frames per worker (sltd, unw, unw_cor, png)
+        _mem_per_worker_mb = 8*max(length_geo*width_geo,
+                                   length_unw*width_unw)*4/2**20
+        _return = tools_lib.run_pool(correct_wrapper, range(n_ifg2), _n_para,
+                                     mem_per_worker_mb=_mem_per_worker_mb)
 
         for i in range(n_ifg2):
             if _return[i][0] == 1:

--- a/bin/LiCSBAS12_loop_closure.py
+++ b/bin/LiCSBAS12_loop_closure.py
@@ -64,13 +64,6 @@ LiCSBAS12_loop_closure.py -d ifgdir [-t tsadir] [-l loop_thre] [--multi_prime]
 #%% Import
 import getopt
 import os
-
-### Limit BLAS threads for the parallel processing by multiprocessing.
-### Must be set before importing numpy (BLAS reads them at load time).
-os.environ["OMP_NUM_THREADS"] = "1"
-os.environ["OPENBLAS_NUM_THREADS"] = "1"
-os.environ["MKL_NUM_THREADS"] = "1"
-
 import sys
 import time
 import shutil

--- a/bin/LiCSBAS12_loop_closure.py
+++ b/bin/LiCSBAS12_loop_closure.py
@@ -64,6 +64,13 @@ LiCSBAS12_loop_closure.py -d ifgdir [-t tsadir] [-l loop_thre] [--multi_prime]
 #%% Import
 import getopt
 import os
+
+### Limit BLAS threads for the parallel processing by multiprocessing.
+### Must be set before importing numpy (BLAS reads them at load time).
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+
 import sys
 import time
 import shutil
@@ -92,7 +99,7 @@ def main(argv=None):
         argv = sys.argv
 
     start = time.time()
-    ver="1.6.5"; date=20260320; author="Y. Morishita"
+    ver="1.6.6"; date=20260818; author="Y. Morishita"
     print("\n{} ver{} {} {}".format(os.path.basename(argv[0]), ver, date, author), flush=True)
     print("{} {}".format(os.path.basename(argv[0]), ' '.join(argv[1:])), flush=True)
 
@@ -116,7 +123,6 @@ def main(argv=None):
     cycle = 3 # 2pi*3/cycle
     cmap_noise = 'viridis'
     cmap_noise_r = 'viridis_r'
-    q = multi.get_context('fork')
 
 
     #%% Read options
@@ -317,9 +323,12 @@ def main(argv=None):
     good_ifg = []
 
     ### Parallel processing
-    p = q.Pool(_n_para)
-    loop_ph_rms_ifg = np.array(p.map(loop_closure_1st_wrapper, range(n_loop)), dtype=np.float32)
-    p.close()
+    ### ~6 float32 frames per worker (3 unw + loop_ph + png)
+    mem_per_worker_mb = 6*length*width*4/2**20
+    loop_ph_rms_ifg = np.array(
+        tools_lib.run_pool(loop_closure_1st_wrapper, range(n_loop), _n_para,
+                           mem_per_worker_mb=mem_per_worker_mb),
+        dtype=np.float32)
 
 
     for i in range(n_loop):
@@ -389,9 +398,11 @@ def main(argv=None):
     print('with {} parallel processing...'.format(_n_para2), flush=True)
 
     ### Parallel processing
-    p = q.Pool(_n_para2)
-    res = np.array(p.map(loop_closure_2nd_wrapper, args), dtype=np.float32)
-    p.close()
+    ## Stream results into preallocated res to save memory
+    res = np.empty((len(args), 3, length, width), dtype=np.float32)
+    tools_lib.run_pool(loop_closure_2nd_wrapper, args, _n_para2,
+                       mem_per_worker_mb=mem_per_worker_mb,
+                       chunksize=1, out=res)
 
     ns_loop_ph = np.sum(res[:, 0, :, :,], axis=0)
     ns_loop_ph[ns_loop_ph==0] = np.nan # To avoid 0 division
@@ -455,9 +466,10 @@ def main(argv=None):
     print('with {} parallel processing...'.format(_n_para), flush=True)
 
     ### Parallel processing
-    p = q.Pool(_n_para)
-    loop_ph_rms_ifg2 = list(np.array(p.map(loop_closure_3rd_wrapper, range(n_loop)), dtype=np.float32))
-    p.close()
+    loop_ph_rms_ifg2 = list(np.array(
+        tools_lib.run_pool(loop_closure_3rd_wrapper, range(n_loop), _n_para,
+                           mem_per_worker_mb=mem_per_worker_mb),
+        dtype=np.float32))
 
     bad_ifg_cand2 = []
     good_ifg2 = []
@@ -525,9 +537,11 @@ def main(argv=None):
     print('with {} parallel processing...'.format(_n_para2), flush=True)
 
     ### Parallel processing
-    p = q.Pool(_n_para2)
-    res = np.array(p.map(loop_closure_4th_wrapper, args), dtype=np.int16)
-    p.close()
+    ## Stream results into preallocated res to save memory
+    res = np.empty((len(args), length, width), dtype=np.int16)
+    tools_lib.run_pool(loop_closure_4th_wrapper, args, _n_para2,
+                       mem_per_worker_mb=mem_per_worker_mb,
+                       chunksize=1, out=res)
 
     ns_loop_err = np.sum(res[:, :, :,], axis=0)
 

--- a/bin/LiCSBAS13_sb_inv.py
+++ b/bin/LiCSBAS13_sb_inv.py
@@ -559,8 +559,8 @@ def main(argv=None):
                 # Number of ifgs for each loop at eath point.
                 # 3 means complete loop, 1 or 2 means broken loop.
                 ns_ifg4loop = cp.array([
-                        (cp.abs(Aloop_cp[i, :])*(~cp.isnan(unwpatch_cp))).sum(axis=1)
-                        for i in range(n_loop)])
+                        (cp.abs(Aloop_cp[i, :])*(~cp.isnan(unwpatch_cp))).sum(
+                            axis=1, dtype=cp.int16) for i in range(n_loop)])
                 bool_loop = (ns_ifg4loop==3)
                 #(n_loop,n_pt) identify complete loop only
 
@@ -569,7 +569,7 @@ def main(argv=None):
                 ns_loop4ifg = cp.array([(
                         (cp.abs(Aloop_cp[:, i])*bool_loop.T).T*
                         (~cp.isnan(unwpatch_cp[:, i]))
-                        ).sum(axis=0) for i in range(n_ifg)]) #
+                        ).sum(axis=0, dtype=cp.int32) for i in range(n_ifg)]) #
 
                 ns_ifg_noloop_tmp = (ns_loop4ifg==0).sum(axis=0) #n_pt
                 ns_nan_ifg = cp.isnan(unwpatch_cp).sum(axis=1) #n_pt, nan ifg count
@@ -595,8 +595,11 @@ def main(argv=None):
 
                 ### Devide unwpatch by n_para for parallel processing
                 _n_loop = Aloop.shape[0] if len(Aloop) != 0 else 0
-                _mem_per_worker_mb = (2*(n_ifg+_n_loop)*
-                    np.ceil(n_pt_unnan/n_para_gap)*4/2**20) ## temp arrays
+                ### At peak count_gaps_wrapper holds ns_loop4ifg
+                ### (n_ifg, n_pt) int32, two int8 temporaries of (n_pt, n_loop)
+                ### each, bool_loop (n_loop, n_pt) and _gap_patch (n_im-1, n_pt)
+                _mem_per_worker_mb = ((4*n_ifg + 3*_n_loop + n_im)*
+                    np.ceil(n_pt_unnan/n_para_gap)/2**20)
                 _result = np.array(
                     tools_lib.run_pool(count_gaps_wrapper, range(n_para_gap),
                                        n_para_gap,
@@ -881,7 +884,8 @@ def count_gaps_wrapper(i):
     # 3 means complete loop, 1 or 2 means broken loop.
     ns_ifg4loop = np.array([(np.abs(Aloop[j, :])*
                          (~np.isnan(unwpatch[i*n_pt_patch:(i+1)*n_pt_patch])))
-                            .sum(axis=1) for j in range(n_loop)])
+                            .sum(axis=1, dtype=np.int16) for j in range(n_loop)])
+                    ## int16: 0-3 ifgs in a loop
     bool_loop = (ns_ifg4loop==3) #(n_loop,n_pt) identify complete loop only
     del ns_ifg4loop
 
@@ -890,7 +894,8 @@ def count_gaps_wrapper(i):
     ns_loop4ifg = np.array([(
             (np.abs(Aloop[:, j])*bool_loop.T).T*
             (~np.isnan(unwpatch[i*n_pt_patch:(i+1)*n_pt_patch, j]))
-            ).sum(axis=0) for j in range(n_ifg)]) #
+            ).sum(axis=0, dtype=np.int32) for j in range(n_ifg)]) #
+                    ## int32: counts loops, up to n_loop
     del bool_loop
 
     ns_ifg_noloop_tmp = (ns_loop4ifg==0).sum(axis=0) #n_pt

--- a/bin/LiCSBAS13_sb_inv.py
+++ b/bin/LiCSBAS13_sb_inv.py
@@ -79,6 +79,14 @@ LiCSBAS13_sb_inv.py -d ifgdir [-t tsadir] [--inv_alg LS|WLS] [--mem_size float] 
 #%% Import
 import getopt
 import os
+
+### Limit BLAS threads because np.linalg.lstsq uses full CPU but is not much
+### faster than 1CPU. Instead parallelize by multiprocessing. Must be set
+### before importing numpy (BLAS reads them at load time).
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+
 import sys
 import re
 import time
@@ -108,7 +116,7 @@ def main(argv=None):
         argv = sys.argv
 
     start = time.time()
-    ver="1.5.4"; date=20260320; author="Y. Morishita"
+    ver="1.5.5"; date=20260818; author="Y. Morishita"
     print("\n{} ver{} {} {}".format(os.path.basename(argv[0]), ver, date, author), flush=True)
     print("{} {}".format(os.path.basename(argv[0]), ' '.join(argv[1:])), flush=True)
 
@@ -129,10 +137,6 @@ def main(argv=None):
     except:
         n_para = max(multi.cpu_count()-1, 1)
 
-    os.environ["OMP_NUM_THREADS"] = "1"
-    # Because np.linalg.lstsq use full CPU but not much faster than 1CPU.
-    # Instead parallelize by multiprocessing
-
     memory_size = 8000
     gamma = 0.0001
     n_unw_r_thre = []
@@ -142,7 +146,6 @@ def main(argv=None):
     cmap_noise = 'viridis'
     cmap_noise_r = 'viridis_r'
     cmap_wrap = tools_lib.get_cmap('cm_insar')
-    q = multi.get_context('fork')
     compress = 'gzip'
 
 
@@ -599,10 +602,14 @@ def main(argv=None):
                       flush=True)
 
                 ### Devide unwpatch by n_para for parallel processing
-                p = q.Pool(n_para_gap)
-                _result = np.array(p.map(count_gaps_wrapper, range(n_para_gap)),
-                                   dtype=object)
-                p.close()
+                _n_loop = Aloop.shape[0] if len(Aloop) != 0 else 0
+                _mem_per_worker_mb = (2*(n_ifg+_n_loop)*
+                    np.ceil(n_pt_unnan/n_para_gap)*4/2**20) ## temp arrays
+                _result = np.array(
+                    tools_lib.run_pool(count_gaps_wrapper, range(n_para_gap),
+                                       n_para_gap,
+                                       mem_per_worker_mb=_mem_per_worker_mb),
+                    dtype=object)
 
                 ns_gap_patch[ix_unnan_pt] = np.hstack(_result[:, 0]) #n_pt
                 gap_patch[:, ix_unnan_pt] = np.hstack(_result[:, 1]) #n_im-1, n_pt
@@ -798,21 +805,24 @@ def main(argv=None):
 
 
     #%% Output png images
+    ### Run serially if gpu because fork after CUDA init is unsafe
+    _mem_per_worker_png_mb = 4*length*width*4/2**20
+
     ### Incremental displacement
     _n_para = n_im-1 if n_para > n_im-1 else n_para
+    if gpu: _n_para = 1
     print('\nOutput increment png images with {} parallel processing...'.format(_n_para), flush=True)
-    p = q.Pool(_n_para)
-    p.map(inc_png_wrapper, range(n_im-1))
-    p.close()
+    tools_lib.run_pool(inc_png_wrapper, range(n_im-1), _n_para,
+                       mem_per_worker_mb=_mem_per_worker_png_mb)
 
     ### Residual for each ifg. png and txt.
     with open(restxtfile, "w") as f:
         print('# RMS of residual (mm)', file=f)
     _n_para = n_ifg if n_para > n_ifg else n_para
+    if gpu: _n_para = 1
     print('\nOutput residual png images with {} parallel processing...'.format(_n_para), flush=True)
-    p = q.Pool(_n_para)
-    p.map(resid_png_wrapper, range(n_ifg))
-    p.close()
+    tools_lib.run_pool(resid_png_wrapper, range(n_ifg), _n_para,
+                       mem_per_worker_mb=_mem_per_worker_png_mb)
 
     ### Velocity and noise indices
     cmins = [None, None, None, None, None, None]

--- a/bin/LiCSBAS13_sb_inv.py
+++ b/bin/LiCSBAS13_sb_inv.py
@@ -79,14 +79,6 @@ LiCSBAS13_sb_inv.py -d ifgdir [-t tsadir] [--inv_alg LS|WLS] [--mem_size float] 
 #%% Import
 import getopt
 import os
-
-### Limit BLAS threads because np.linalg.lstsq uses full CPU but is not much
-### faster than 1CPU. Instead parallelize by multiprocessing. Must be set
-### before importing numpy (BLAS reads them at load time).
-os.environ["OMP_NUM_THREADS"] = "1"
-os.environ["OPENBLAS_NUM_THREADS"] = "1"
-os.environ["MKL_NUM_THREADS"] = "1"
-
 import sys
 import re
 import time
@@ -805,12 +797,10 @@ def main(argv=None):
 
 
     #%% Output png images
-    ### Run serially if gpu because fork after CUDA init is unsafe
     _mem_per_worker_png_mb = 4*length*width*4/2**20
 
     ### Incremental displacement
     _n_para = n_im-1 if n_para > n_im-1 else n_para
-    if gpu: _n_para = 1
     print('\nOutput increment png images with {} parallel processing...'.format(_n_para), flush=True)
     tools_lib.run_pool(inc_png_wrapper, range(n_im-1), _n_para,
                        mem_per_worker_mb=_mem_per_worker_png_mb)
@@ -819,7 +809,6 @@ def main(argv=None):
     with open(restxtfile, "w") as f:
         print('# RMS of residual (mm)', file=f)
     _n_para = n_ifg if n_para > n_ifg else n_para
-    if gpu: _n_para = 1
     print('\nOutput residual png images with {} parallel processing...'.format(_n_para), flush=True)
     tools_lib.run_pool(resid_png_wrapper, range(n_ifg), _n_para,
                        mem_per_worker_mb=_mem_per_worker_png_mb)

--- a/bin/LiCSBAS13_sb_inv.py
+++ b/bin/LiCSBAS13_sb_inv.py
@@ -797,7 +797,9 @@ def main(argv=None):
 
 
     #%% Output png images
-    _mem_per_worker_png_mb = 4*length*width*4/2**20
+    ### Approx memory use per worker (MB): ~12 frames (inputs, wrapped
+    ### results, complex64 temporaries and matplotlib's float32 copy)
+    _mem_per_worker_png_mb = 12*length*width*4/2**20*1.5 ## 1.5 for margin
 
     ### Incremental displacement
     _n_para = n_im-1 if n_para > n_im-1 else n_para

--- a/bin/LiCSBAS16_filt_ts.py
+++ b/bin/LiCSBAS16_filt_ts.py
@@ -72,12 +72,6 @@ Note: Spatial filter consume large memory. If the processing is stacked, try
 import os
 
 os.environ['QT_QPA_PLATFORM']='offscreen'
-### Limit BLAS threads because np.linalg.lstsq uses full CPU but is not much
-### faster than 1CPU. Instead parallelize by multiprocessing. Must be set
-### before importing numpy (BLAS reads them at load time).
-os.environ["OMP_NUM_THREADS"] = "1"
-os.environ["OPENBLAS_NUM_THREADS"] = "1"
-os.environ["MKL_NUM_THREADS"] = "1"
 
 from astropy.convolution import Gaussian2DKernel, convolve_fft
 import datetime as dt
@@ -120,7 +114,7 @@ def main(argv=None):
     global cum, mask, deg_ramp, hgt_linearflag, hgt, hgt_min, hgt_max,\
     filtcumdir, filtincdir, imdates, cycle, coef_r2m, models, \
     filtwidth_yr, filtwidth_km, dt_cum, x_stddev, y_stddev, mask2, cmap_wrap
-    global cum_org, cum_filt, gpu
+    global cum_org, cum_filt
 
 
     #%% Set default
@@ -133,7 +127,6 @@ def main(argv=None):
     hgt_min = 200 ## meter
     hgt_max = 10000 ## meter
     maskflag = True
-    gpu = False
 
     try:
         n_para = max(len(os.sched_getaffinity(0))-1, 1)
@@ -159,7 +152,7 @@ def main(argv=None):
             opts, args = getopt.getopt(argv[1:], "ht:s:y:r:",
                            ["help", "demerr", "hgt_linear", "hgt_min=", "hgt_max=",
                             "nomask", "n_para=", "range=", "range_geo=",
-                            "ex_range=", "ex_range_geo=", "gpu"])
+                            "ex_range=", "ex_range_geo="])
         except getopt.error as msg:
             raise Usage(msg)
         for o, a in opts:
@@ -194,8 +187,6 @@ def main(argv=None):
                 ex_range_str = a
             elif o == '--ex_range_geo':
                 ex_range_geo_str = a
-            elif o == '--gpu':
-                gpu = True
 
         if not tsadir:
             raise Usage('No tsa directory given, -t is not optional!')
@@ -207,9 +198,6 @@ def main(argv=None):
             raise Usage('Both --range and --range_geo given, use either one not both!')
         if ex_range_str and ex_range_geo_str:
             raise Usage('Both --ex_range and --ex_range_geo given, use either one not both!')
-        if gpu:
-            print("\nGPU option is activated. Need cupy module.\n")
-            import cupy as cp
 
     except Usage as err:
         print("\nERROR:", file=sys.stderr, end='')
@@ -413,9 +401,7 @@ def main(argv=None):
         else:
             print('\nDeramp ifgs with the degree of {} and hgt-linear,'.format(deg_ramp), flush=True)
 
-        if n_para == 1 or gpu:
-            if gpu: print('With GPU')
-        else:
+        if n_para != 1:
             print('with {} parallel processing...'.format(n_para), flush=True)
 
         models = np.zeros(n_im, dtype=object)
@@ -424,16 +410,13 @@ def main(argv=None):
             cum[i, :, :] = result[0]
             models[i] = result[1]
 
-        tools_lib.run_pool(deramp_wrapper, range(n_im),
-                           1 if gpu else n_para,
+        tools_lib.run_pool(deramp_wrapper, range(n_im), n_para,
                            mem_per_worker_mb=mem_per_worker_mb,
                            chunksize=1, store=store_deramp)
 
         ### Only for output increment png files
-        ### Run serially if gpu because fork after CUDA init is unsafe
-        print('\nCreate png for increment with {} parallel processing...'.format(1 if gpu else n_para), flush=True)
-        tools_lib.run_pool(deramp_wrapper2, range(1, n_im),
-                           1 if gpu else n_para,
+        print('\nCreate png for increment with {} parallel processing...'.format(n_para), flush=True)
+        tools_lib.run_pool(deramp_wrapper2, range(1, n_im), n_para,
                            mem_per_worker_mb=mem_per_worker_png_mb)
         del cum_org
 
@@ -486,18 +469,17 @@ def main(argv=None):
 
     print('\nHP filter in time, LP filter in space,', flush=True)
 
-    ### Run serially if gpu because fork after CUDA init is unsafe
-    if n_para != 1 and not gpu:
+    if n_para != 1:
         print('with {} parallel processing...'.format(n_para), flush=True)
     ## Stream results into cum_filt to save memory
-    tools_lib.run_pool(filter_wrapper, range(n_im), 1 if gpu else n_para,
+    tools_lib.run_pool(filter_wrapper, range(n_im), n_para,
                        mem_per_worker_mb=mem_per_worker_mb,
                        chunksize=1, out=cum_filt)
 
 
     ### Only for output increment png files
-    print('\nCreate png for increment with {} parallel processing...'.format(1 if gpu else n_para), flush=True)
-    tools_lib.run_pool(filter_wrapper2, range(1, n_im), 1 if gpu else n_para,
+    print('\nCreate png for increment with {} parallel processing...'.format(n_para), flush=True)
+    tools_lib.run_pool(filter_wrapper2, range(1, n_im), n_para,
                        mem_per_worker_mb=mem_per_worker_png_mb)
 
 
@@ -677,7 +659,7 @@ def deramp_wrapper(i):
         print("  {0:3}/{1:3}th image...".format(i, len(imdates)), flush=True)
 
     fit, model = tools_lib.fit2dh(cum_org[i, :, :]*mask*mask2, deg_ramp, hgt,
-                                  hgt_min, hgt_max, gpu=gpu) ## fit is not masked
+                                  hgt_min, hgt_max) ## fit is not masked
     _cum = cum_org[i, :, :]-fit
 
     if hgt_linearflag:

--- a/bin/LiCSBAS16_filt_ts.py
+++ b/bin/LiCSBAS16_filt_ts.py
@@ -255,13 +255,6 @@ def main(argv=None):
     if n_para > n_im:
         n_para = n_im
 
-    ### Approx memory use per worker in deramp/filter (MB). n_para is capped
-    ### by tools_lib.run_pool with this value and the memory available at the
-    ### time of each parallel processing.
-    safety_factor = 3
-    mem_per_worker_mb = length*width*3*4*4*safety_factor/2**20 #MB
-    mem_per_worker_png_mb = 4*length*width*4/2**20 #MB, for png creation
-
     ### Calc dt in year
     imdates_dt = ([dt.datetime.strptime(imd, '%Y%m%d').toordinal() for imd in imdates])
     dt_cum = np.float32((np.array(imdates_dt)-imdates_dt[0])/365.25)
@@ -289,6 +282,34 @@ def main(argv=None):
     ### temporal filter width
     if not filtwidth_yr and filtwidth_yr != 0:
         filtwidth_yr = dt_cum[-1]/(n_im-1)*3 ## avg interval*3
+
+    ### Approx memory use per worker (MB). n_para is capped by
+    ### tools_lib.run_pool with this value and the memory available at the
+    ### time of each parallel processing.
+    safety_factor = 1.5 ## for next_fast_len rounding and FFT workspace
+    ### The two heavy stages of filter_wrapper do not overlap because the
+    ### temporal temporaries are deleted before convolve_fft, so take the
+    ### larger of:
+    ###  - HP in time: 3 float32 arrays of n_im_t frames alive at once
+    ###  - LP in space: astropy pads the frame by the kernel size (8*stddev)
+    ###    and keeps ~10 complex128 arrays of that padded size alive at once,
+    ###    i.e. memory grows rapidly with filtwidth_km
+    if filtwidth_yr:
+        n_im_t = int((np.abs(dt_cum-dt_cum[:, None]) <
+                      filtwidth_yr*4).sum(axis=1).max())
+    else:
+        n_im_t = 1
+    _mem_hpt_mb = n_im_t*length*width*4*3/2**20
+    if filtwidth_km == 0:
+        _mem_lps_mb = 0
+    else:
+        _ksize = Gaussian2DKernel(x_stddev, y_stddev).shape
+        _mem_lps_mb = 10*16*(length+_ksize[0])*(width+_ksize[1])/2**20
+    mem_per_worker_mb = max(_mem_hpt_mb, _mem_lps_mb)*safety_factor
+
+    ### png wrappers: ~12 frames (3 differences, 3 wrapped results, complex64
+    ### temporaries of the wrapping, and matplotlib's float32 copy)
+    mem_per_worker_png_mb = 12*length*width*4/2**20*safety_factor
 
     ### hgt_linear
     if hgt_linearflag:

--- a/bin/LiCSBAS16_filt_ts.py
+++ b/bin/LiCSBAS16_filt_ts.py
@@ -69,10 +69,19 @@ Note: Spatial filter consume large memory. If the processing is stacked, try
 """
 
 #%% Import
+import os
+
+os.environ['QT_QPA_PLATFORM']='offscreen'
+### Limit BLAS threads because np.linalg.lstsq uses full CPU but is not much
+### faster than 1CPU. Instead parallelize by multiprocessing. Must be set
+### before importing numpy (BLAS reads them at load time).
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+
 from astropy.convolution import Gaussian2DKernel, convolve_fft
 import datetime as dt
 import getopt
-import os
 import shutil
 import sys
 import time
@@ -81,15 +90,12 @@ import warnings
 import h5py as h5
 import multiprocessing as multi
 import numpy as np
-import psutil
 
 import LiCSBAS_io_lib as io_lib
 import LiCSBAS_tools_lib as tools_lib
 import LiCSBAS_inv_lib as inv_lib
 import LiCSBAS_plot_lib as plot_lib
 import SCM
-
-os.environ['QT_QPA_PLATFORM']='offscreen'
 
 
 class Usage(Exception):
@@ -106,7 +112,7 @@ def main(argv=None):
         argv = sys.argv
 
     start = time.time()
-    ver="1.6.3"; date=20260805; author="Y. Morishita"
+    ver="1.6.4"; date=20260818; author="Y. Morishita"
     print("\n{} ver{} {} {}".format(os.path.basename(argv[0]), ver, date, author), flush=True)
     print("{} {}".format(os.path.basename(argv[0]), ' '.join(argv[1:])), flush=True)
 
@@ -134,10 +140,6 @@ def main(argv=None):
     except:
         n_para = max(multi.cpu_count()-1, 1)
 
-    os.environ["OMP_NUM_THREADS"] = "1"
-    # Because np.linalg.lstsq use full CPU but not much faster than 1CPU.
-    # Instead parallelize by multiprocessing
-
     range_str = []
     range_geo_str = []
     ex_range_str = []
@@ -148,7 +150,6 @@ def main(argv=None):
     cmap_vel = SCM.roma.reversed()
     cmap_noise_r = 'viridis_r'
     cmap_wrap = tools_lib.get_cmap('cm_insar')
-    q = multi.get_context('fork')
     compress = 'gzip'
 
 
@@ -266,11 +267,12 @@ def main(argv=None):
     if n_para > n_im:
         n_para = n_im
 
-    # Control n_para depending on available memory
+    ### Approx memory use per worker in deramp/filter (MB). n_para is capped
+    ### by tools_lib.run_pool with this value and the memory available at the
+    ### time of each parallel processing.
     safety_factor = 3
-    mem_avail = (psutil.virtual_memory().available)/2**20 #MB
-    filter_size_approx = length*width*3*4*4*safety_factor/2**20 #MB
-    n_para = max(min(n_para, int(mem_avail/2/filter_size_approx)), 1)
+    mem_per_worker_mb = length*width*3*4*4*safety_factor/2**20 #MB
+    mem_per_worker_png_mb = 4*length*width*4/2**20 #MB, for png creation
 
     ### Calc dt in year
     imdates_dt = ([dt.datetime.strptime(imd, '%Y%m%d').toordinal() for imd in imdates])
@@ -413,27 +415,26 @@ def main(argv=None):
 
         if n_para == 1 or gpu:
             if gpu: print('With GPU')
-            models = np.zeros(n_im, dtype=object)
-            for i in range(n_im):
-                cum[i, :, :], models[i] = deramp_wrapper(i)
         else:
             print('with {} parallel processing...'.format(n_para), flush=True)
-            ### Parallel processing
-            p = q.Pool(n_para)
-            _result = np.array(p.map(deramp_wrapper, range(n_im)), dtype=object)
-            p.close()
-            del args
 
-            models = _result[:, 1]
-            for i in range(n_im):
-                cum[i, :, :] = _result[i, 0]
-            del _result
+        models = np.zeros(n_im, dtype=object)
+        def store_deramp(i, result):
+            ## Stream results into cum to save memory
+            cum[i, :, :] = result[0]
+            models[i] = result[1]
+
+        tools_lib.run_pool(deramp_wrapper, range(n_im),
+                           1 if gpu else n_para,
+                           mem_per_worker_mb=mem_per_worker_mb,
+                           chunksize=1, store=store_deramp)
 
         ### Only for output increment png files
-        print('\nCreate png for increment with {} parallel processing...'.format(n_para), flush=True)
-        p = q.Pool(n_para)
-        p.map(deramp_wrapper2, range(1, n_im))
-        p.close()
+        ### Run serially if gpu because fork after CUDA init is unsafe
+        print('\nCreate png for increment with {} parallel processing...'.format(1 if gpu else n_para), flush=True)
+        tools_lib.run_pool(deramp_wrapper2, range(1, n_im),
+                           1 if gpu else n_para,
+                           mem_per_worker_mb=mem_per_worker_png_mb)
         del cum_org
 
 
@@ -485,22 +486,19 @@ def main(argv=None):
 
     print('\nHP filter in time, LP filter in space,', flush=True)
 
-    if n_para == 1:
-        for i in range(n_im):
-            cum_filt[i, :, :] = np.float32(filter_wrapper(i))
-    else:
+    ### Run serially if gpu because fork after CUDA init is unsafe
+    if n_para != 1 and not gpu:
         print('with {} parallel processing...'.format(n_para), flush=True)
-        ### Parallel processing
-        p = q.Pool(n_para)
-        cum_filt[:, :, :] = np.array(p.map(filter_wrapper, range(n_im)), dtype=np.float32)
-        p.close()
+    ## Stream results into cum_filt to save memory
+    tools_lib.run_pool(filter_wrapper, range(n_im), 1 if gpu else n_para,
+                       mem_per_worker_mb=mem_per_worker_mb,
+                       chunksize=1, out=cum_filt)
 
 
     ### Only for output increment png files
-    print('\nCreate png for increment with {} parallel processing...'.format(n_para), flush=True)
-    p = q.Pool(n_para)
-    p.map(filter_wrapper2, range(1, n_im))
-    p.close()
+    print('\nCreate png for increment with {} parallel processing...'.format(1 if gpu else n_para), flush=True)
+    tools_lib.run_pool(filter_wrapper2, range(1, n_im), 1 if gpu else n_para,
+                       mem_per_worker_mb=mem_per_worker_png_mb)
 
 
     #%% Find stable ref point

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ psutil=5.9.0
 requests=2.32.3
 shapely=2.0.6
 statsmodels=0.14.4
+threadpoolctl=3.5.0

--- a/tests/test_inv_lib.py
+++ b/tests/test_inv_lib.py
@@ -178,6 +178,21 @@ def test_invert_nsbas_wls():
     np.testing.assert_allclose(vel, vel_true, atol=0.01)
 
 
+def test_invert_nsbas_wls_ncore2_matches_ncore1():
+    rng = np.random.default_rng(8)
+    n_pt = 30
+    vel_true = rng.uniform(-20, 20, n_pt)
+    unw, _ = forward_model_unw(vel_true, n_pt)
+    unw = unw.astype(np.float32)
+    unw[rng.random(unw.shape) < 0.15] = np.nan
+    var = np.full_like(unw, 2.0)
+    G = inv_lib.make_sb_matrix(IFGDATES)
+    res1 = inv_lib.invert_nsbas_wls(unw.copy(), var, G, DT_CUM, 0.0001, 1)
+    res2 = inv_lib.invert_nsbas_wls(unw.copy(), var, G, DT_CUM, 0.0001, 2)
+    for a, b in zip(res1, res2):
+        np.testing.assert_allclose(a, b, rtol=1e-6, atol=1e-6)
+
+
 #%% Bootstrap velocity std (seeded -> deterministic)
 def test_calc_velstd_withnan():
     rng = np.random.default_rng(7)

--- a/tests/test_tools_lib.py
+++ b/tests/test_tools_lib.py
@@ -1,4 +1,8 @@
 """Unit tests for LiCSBAS_tools_lib."""
+import pathlib
+import subprocess
+import sys
+
 import numpy as np
 import pytest
 
@@ -126,6 +130,83 @@ def test_convert_size():
     assert tools_lib.convert_size(1024) == '1.0KB'
     assert tools_lib.convert_size(1536) == '1.5KB'
     assert tools_lib.convert_size(5 * 1024**3) == '5.0GB'
+
+
+#%% run_pool
+def _square(i):
+    return i * i
+
+
+def _row(i):
+    return np.full(4, i, dtype=np.float32)
+
+
+def _pair(i):
+    return i, i * i
+
+
+@pytest.mark.parametrize('n_para', [1, 3])  # serial path and parallel path
+def test_run_pool_preserves_order(n_para):
+    assert tools_lib.run_pool(_square, range(50), n_para) \
+        == [i * i for i in range(50)]
+
+
+def test_run_pool_empty_args():
+    assert tools_lib.run_pool(_square, [], 4) == []
+
+
+def test_run_pool_out_streaming():
+    out = np.empty((10, 4), dtype=np.float32)
+    ret = tools_lib.run_pool(_row, range(10), 3, chunksize=1, out=out)
+    assert ret is out
+    expected = np.repeat(np.arange(10, dtype=np.float32)[:, None], 4, axis=1)
+    np.testing.assert_array_equal(out, expected)
+
+
+def test_run_pool_store():
+    firsts = np.empty(10, dtype=np.int64)
+    seconds = np.empty(10, dtype=np.int64)
+
+    def store(i, result):
+        firsts[i], seconds[i] = result
+
+    tools_lib.run_pool(_pair, range(10), 3, store=store)
+    np.testing.assert_array_equal(firsts, np.arange(10))
+    np.testing.assert_array_equal(seconds, np.arange(10) ** 2)
+
+
+def test_run_pool_mem_cap(capsys):
+    # Absurdly large per-worker memory must cap n_para to 1 but still work
+    result = tools_lib.run_pool(_square, range(10), 4,
+                                mem_per_worker_mb=10**12)
+    assert result == [i * i for i in range(10)]
+    assert 'Reduce n_para' in capsys.readouterr().out
+
+
+@pytest.mark.skipif(sys.platform != 'linux', reason='needs SIGKILL')
+def test_run_pool_dead_worker_raises_instead_of_hanging():
+    # A worker killed mid-map (like by the OOM killer) must raise a clear
+    # error. Run in a subprocess with a hard timeout so that a regression
+    # (hang, as plain Pool.map does) can never hang the test session.
+    lib_dir = str(pathlib.Path(__file__).resolve().parent.parent
+                  / 'LiCSBAS_lib')
+    code = '\n'.join([
+        'import os, signal, sys, time',
+        'sys.path.insert(0, {!r})'.format(lib_dir),
+        'import LiCSBAS_tools_lib as tools_lib',
+        'def f(i):',
+        '    if i == 3: os.kill(os.getpid(), signal.SIGKILL)',
+        '    time.sleep(0.01)',
+        '    return i',
+        'try:',
+        '    tools_lib.run_pool(f, range(8), 2, chunksize=1)',
+        'except RuntimeError as e:',
+        '    assert "n_para" in str(e)',
+        '    print("OK")',
+    ])
+    res = subprocess.run([sys.executable, '-c', code], timeout=60,
+                         capture_output=True, text=True)
+    assert 'OK' in res.stdout, res.stderr
 
 
 #%% calculate_common_geometry


### PR DESCRIPTION
## Problem

Steps 03, 13, and 16 (and potentially 12) frequently hang during parallel processing when memory usage approaches 100% (small-RAM machines with large data).

**Root cause** (empirically verified): when memory runs out, the Linux OOM killer SIGKILLs a pool worker. A bare `multiprocessing.Pool.map()` then waits forever for the lost result (long-standing CPython issue bpo-22393, unfixed through 3.13). All parallel sites in the repo used bare `p.map()` with no error handling, and per-worker memory consumption was not accounted for anywhere. In addition, the two pools in `LiCSBAS_inv_lib.py` were never closed, leaking a whole set of forked workers per patch iteration in step13 and inflating resident memory.

## Fix

### `tools_lib.run_pool()`

A robust drop-in replacement for the fork `Pool.map` pattern:

- keeps the fork start method and the fork-inherited-globals worker pattern unchanged
- raises a `RuntimeError` within seconds when a worker dies, instead of hanging forever (uses `ProcessPoolExecutor(mp_context=fork)` / `BrokenProcessPool` under the hood). The message names the exception and presents OOM as the most likely rather than the certain cause, since a worker that segfaults in a library arrives at the same handler
- optionally caps `n_para` just-in-time from currently available memory and a per-worker memory estimate (`mem_per_worker_mb`)
- optionally streams results one by one into a preallocated array (`out=`/`store=`), removing the extra cube-sized transient of `np.array(p.map(...))` in steps 12/16
- limits BLAS/OpenMP threads to 1 **in each worker** (via a `threadpoolctl` initializer), so `n_para` workers x N BLAS threads no longer oversubscribe the CPU
- guarantees close/join via context manager

All 10 pools in steps 03/12/13/16 and `inv_lib` are migrated to it (which also fixes the inv_lib pool leak). Other scripts (steps 01/02/04/05, etc.) keep the old pattern for now and can be migrated later. `threadpoolctl` is added to `requirements.txt` / `LiCSBAS.yml`; if it is missing, `run_pool` falls back to the previous behavior (only risking oversubscription).

### Per-worker memory estimates derived from what the workers allocate

The estimates that feed `mem_per_worker_mb` were guesses. They are now read off the code:

- **step16 filter/deramp pool.** The two heavy stages of `filter_wrapper` do not overlap (the temporal temporaries are deleted before `convolve_fft`), so the estimate takes the larger of: the HP-in-time stage, which keeps 3 float32 arrays of `n_im_t` frames alive (`n_im_t` = images within `filtwidth_yr*4`, ~24 by default); and the LP-in-space stage, where astropy's `convolve_fft` with `boundary='fill'` pads the frame by the kernel size (`Gaussian2DKernel` defaults to 8*stddev) and keeps ~10 **complex128** arrays of that padded size alive at once. Memory therefore grows rapidly with `filtwidth_km`, which the old frame-sized estimate did not capture at all — it is ~33x low for a 200x200 frame with `-s 10`, while being roughly right for the default 2 km on a large frame. Because the estimate is now derived rather than guessed, `safety_factor` drops from 3 to 1.5 (`run_pool` still halves the available memory on top).
- **png pools** in steps 16 and 13: ~12 frames (differences, wrapped results, the complex64 temporaries of the wrapping, and matplotlib's float32 copy) instead of 4.
- **step13 `count_gaps`**: the old estimate counted a single `(n_pt, n_loop)` temporary, but the second stage builds two of them per iteration — measured 375 MB against an estimate of 213 MB.

### Smaller integer types in step13's gap counting

`Aloop` holds only 1, -1 and 0, but `make_loop_matrix` built it with `np.array()` over Python int lists, giving int64, and every temporary derived from it inherited that width (`.sum()` on small ints also promotes the accumulator to int64 unless `dtype` is given). `make_loop_matrix` now returns int8, and `count_gaps_wrapper` sums with `dtype=np.int16` for `ns_ifg4loop` (0-3 ifgs per loop) and `dtype=np.int32` for `ns_loop4ifg` (bounded by `n_loop`); the cupy path gets the same dtypes, which also shrinks the device temporaries.

This also reconciles the stage with the patch splitting. `get_patchrow` is driven by `n_store_data = n_ifg*2 + n_im*2 + n_im*0.3`, which has **no `n_loop` term**, while `count_gaps` scales with `n_loop` and its workers together cover the whole patch. The stage used to exceed the `--mem_size` budget the patches were cut for by 2-7x depending on network density; it now lands at roughly 1x.

### step16 `--gpu` removed

It was undocumented (absent from the usage text) and only reached `fit2dh`, whose docstring already states that the GPU path is slow, may error on large data, and is not recommended; `batch_LiCSBAS.sh` never passed it. `--gpu` in steps 13/14 is unchanged.

## Decisions taken during review

- **BLAS thread limiting is per worker, not process-wide.** master set `OMP_NUM_THREADS=1` *after* `import numpy`, which has no effect since BLAS reads it at load time. Moving it before the import (an earlier revision of this branch) does work, but pins the *whole process* to 1 thread, including the large serial full-frame `lstsq` in the parent (step13 full-unw solve, step16 DEM error estimation). It is therefore scoped to the pool workers instead.
- **Pools that run after CUDA initialization stay parallel** (step13 png output, `inv_lib` point-by-point solve). An earlier revision of this branch serialized them as a precaution, which is a large slowdown for step13's many patch iterations. Forking after CUDA init fails only when the *child* touches CUDA; these workers use numpy/matplotlib only, receive plain (non-pinned) host arrays or re-read their input from files, and master has always forked at these points without trouble. `run_pool` also turns an unexpectedly dead worker into an error rather than a hang, so the failure mode is no longer silent.
- **`Executor.map` result buffering is left as is.** Results are yielded in submission order (as with `Pool.map`), so a task much slower than the ones after it makes the later results pile up in the parent instead of being streamed. Measured with 40 tasks of one 5 MB frame each and 4 workers: **16 MB (3.4 frames) with uniform task times, but 196 MB (41 frames, i.e. everything buffered) when task 0 is 40x slower**. In the migrated pools the per-task cost is close to uniform, and in `filter_wrapper` the images at the ends of the time series are the *fastest* (fewest neighbours in the temporal window), so the pathological ordering does not arise. Bounding it would mean replacing `Executor.map` with throttled `submit`/`as_completed`, which is not worth the complexity here.
- **A preallocated `out=` array is not visible to the memory cap** until its pages are written (`np.zeros`/`np.empty` of that size only maps zero pages; measured: 0 MB drop in `psutil` available on allocation, 189 MB after touching). The `mem_avail/2` reserve in `run_pool` is what covers this.
- **`invert_nsbas_wls`'s parallel path still returns float64** and rebuilds the preallocated float32 `result` via `np.array(_result).T`. This is ~3.2 GB of transient for one patch at the default `--mem_size 8000`, but the WLS path is opt-in (`--inv_alg WLS`, documented as "not well tested") and the amount is not expected to cause OOM, so it is left for later.

## Verification

- `pytest`: 96 passed, including 8 new tests (worker-SIGKILL test proving no-hang behavior, ordering/streaming/memory-cap tests, `invert_nsbas_wls` n_core=2 consistency)
- **Numerical regression**: steps 12→13→16 run on a real dataset (49 images, 184×223, 155 ifgs) with master vs this branch: all datasets in `cum.h5`/`cum_filt.h5` and all step12 text outputs are **bit-identical**. This was verified on the branch state before the BLAS-threading change above; it has not been re-run since.
- **Manual kill test**: `kill -9` on a worker mid-run → parent exits with the clear error within 2 s (previously hung forever)
- **Real OOM reproduction**: running step16 under `systemd-run --scope -p MemoryMax=700M -p MemorySwapMax=0 -p OOMPolicy=continue` triggers actual OOM kills of workers → parent exits promptly with the actionable error instead of hanging
- **BLAS scoping**: workers report `('mkl', 1), ('openmp', 1)` while the parent stays at the full thread count before and after the pool
- **step13 gap counting**: measured peak for n_ifg=155, n_loop=310, n_pt=60000 drops from 375 MB to 91.5 MB, against a new estimate of 91.6 MB. The counters and `ns_ifg_noloop` are identical to the int64 versions, and step12's `np.abs(Aloop).sum(axis=0)` still accumulates in int64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
