### PR TITLE
Fix multiprocessing hangs under memory pressure (steps 02/04/05)

### DIFF
--- a/bin/LiCSBAS02_ml_prep.py
+++ b/bin/LiCSBAS02_ml_prep.py
@@ -75,7 +75,7 @@ def main(argv=None):
         argv = sys.argv
 
     start = time.time()
-    ver="1.7.7"; date=20260829; author="Y. Morishita"
+    ver="1.7.8"; date=20260905; author="Y. Morishita"
     print("\n{} ver{} {} {}".format(os.path.basename(argv[0]), ver, date, author), flush=True)
     print("{} {}".format(os.path.basename(argv[0]), ' '.join(argv[1:])), flush=True)
 
@@ -95,7 +95,6 @@ def main(argv=None):
     cmap_wrap = tools_lib.get_cmap('cm_insar')
     cycle = 3
     n_valid_thre = 0.5
-    q = multi.get_context('fork')
 
 
     #%% Read options
@@ -258,11 +257,39 @@ def main(argv=None):
         if n_para > n_ifg2:
             n_para = n_ifg2
 
+        ### Size of the input geotiff, for the memory estimate below
+        width_in = length_in = 0
+        for ifgd in ifgdates2:
+            try:
+                geotiff = gdal.Open(os.path.join(geocdir, ifgd,
+                                                 ifgd+'.geo.unw.tif'))
+            except RuntimeError: ## not exist or broken
+                continue
+            width_in = geotiff.RasterXSize
+            length_in = geotiff.RasterYSize
+            geotiff = None
+            break
+
+        ### Approx memory use per worker (MB). n_para is capped by
+        ### tools_lib.run_pool with this value and the memory available at
+        ### the time of the parallel processing. The two stages of
+        ### convert_wrapper do not overlap, but the memory of the first is
+        ### not necessarily returned to the OS, so they are summed:
+        ###  - read and multilook: ~3 float32 frames of the input size (unw,
+        ###    the copy np.nanmean makes, and the unw==0 and isnan masks)
+        ###  - png: ~6 float32 frames of the output size (unw, the complex64
+        ###    temporaries of the wrapping, np.angle's output, and
+        ###    matplotlib's own copy)
+        ### 0 (i.e. no cap) if no readable geotiff was found.
+        _length_out = int(length_in/nlook)
+        _width_out = int(width_in/nlook)
+        _mem_per_worker_mb = (3*length_in*width_in +
+                              6*_length_out*_width_out)*4/2**20
+
         ### Create float with parallel processing
         print('  {} parallel processing...'.format(n_para), flush=True)
-        p = q.Pool(n_para)
-        rc = p.map(convert_wrapper, range(n_ifg2))
-        p.close()
+        rc = tools_lib.run_pool(convert_wrapper, range(n_ifg2), n_para,
+                                mem_per_worker_mb=_mem_per_worker_mb)
 
         ifgd_ok = []
         for i, _rc in enumerate(rc):
@@ -410,14 +437,17 @@ def convert_wrapper(i):
         cc[cc==0] = np.nan
         cc = tools_lib.multilook(cc, nlook, nlook, n_valid_thre)
 
-    ### Output float
-    unw.tofile(unwfile)
+    ### Output cc
     cc = cc.astype(np.uint8) ##nan->0, max255, auto-floored
     cc.tofile(ccfile)
 
     ### Make png
     unwpngfile = os.path.join(ifgdir1, ifgd+'.unw.png')
     plot_lib.make_im_png(np.angle(np.exp(1j*unw/cycle)*cycle), unwpngfile, cmap_wrap, ifgd+'.unw', vmin=-np.pi, vmax=np.pi, cbar=False)
+
+    ### Output float last, so that unw does not exist if this worker is
+    ### killed (e.g. by the OOM killer) and the ifg is redone on a rerun
+    unw.tofile(unwfile)
 
     return 0
 

--- a/bin/LiCSBAS04op_mask_unw.py
+++ b/bin/LiCSBAS04op_mask_unw.py
@@ -62,7 +62,7 @@ def main(argv=None):
         argv = sys.argv
 
     start = time.time()
-    ver="1.3.8"; date=20250722; author="Y. Morishita"
+    ver="1.3.9"; date=20260905; author="Y. Morishita"
     print("\n{} ver{} {} {}".format(os.path.basename(argv[0]), ver, date, author), flush=True)
     print("{} {}".format(os.path.basename(argv[0]), ' '.join(argv[1:])), flush=True)
 
@@ -83,7 +83,6 @@ def main(argv=None):
 
     cmap_noise = 'viridis'
     cmap_wrap = tools_lib.get_cmap('cm_insar')
-    q = multi.get_context('fork')
 
 
     #%% Read options
@@ -239,9 +238,15 @@ def main(argv=None):
             n_para = n_ifg2
 
         print('  {} parallel processing...'.format(n_para), flush=True)
-        p = q.Pool(n_para)
-        p.map(mask_wrapper, range(n_ifg2))
-        p.close()
+        ### Approx memory use per worker (MB). n_para is capped by
+        ### tools_lib.run_pool with this value and the memory available at
+        ### the time of the parallel processing. ~7 float32 frames: unw,
+        ### which is alive throughout, and the png stage (the complex64
+        ### temporaries of the wrapping, np.angle's output, and
+        ### matplotlib's own copy).
+        _mem_per_worker_mb = 7*length*width*4/2**20
+        tools_lib.run_pool(mask_wrapper, range(n_ifg2), n_para,
+                           mem_per_worker_mb=_mem_per_worker_mb)
 
     print("", flush=True)
 
@@ -285,8 +290,6 @@ def mask_wrapper(ifgix):
     out_dir1 = os.path.join(out_dir, ifgd)
     if not os.path.exists(out_dir1): os.mkdir(out_dir1)
 
-    unw.tofile(os.path.join(out_dir1, ifgd+'.unw'))
-
     if not os.path.exists(os.path.join(out_dir1, ifgd+'.cc')):
         ccfile = os.path.join(in_dir, ifgd, ifgd+'.cc')
         try:
@@ -294,12 +297,15 @@ def mask_wrapper(ifgix):
                        os.path.join(out_dir1, ifgd+'.cc'))
         except:
             shutil.copy(ccfile, out_dir1)
-        
 
     ## Output png for masked unw
     pngfile = os.path.join(out_dir1, ifgd+'.unw.png')
     title = '{} ({}pi/cycle)'.format(ifgd, cycle*2)
     plot_lib.make_im_png(np.angle(np.exp(1j*unw/cycle)*cycle), pngfile, cmap_wrap, title, -np.pi, np.pi, cbar=False)
+
+    ## Output unw last, so that it does not exist if this worker is killed
+    ## (e.g. by the OOM killer) and the ifg is redone on a rerun
+    unw.tofile(os.path.join(out_dir1, ifgd+'.unw'))
 
 
 #%% main

--- a/bin/LiCSBAS05op_clip_unw.py
+++ b/bin/LiCSBAS05op_clip_unw.py
@@ -266,8 +266,9 @@ def main(argv=None):
         ### Approx memory use per worker (MB). n_para is capped by
         ### tools_lib.run_pool with this value and the memory available at
         ### the time of the parallel processing:
-        ###  - 2 float32 frames of the input size: unw and coh, which stay
-        ###    alive at full size because the clipped arrays are views
+        ###  - 2 float32 frames of the input size: unw and coh are read at
+        ###    full size before being clipped, and freeing them does not
+        ###    lower the peak RSS of the worker
         ###  - ~6 float32 frames of the clipped size for the png stage (the
         ###    complex64 temporaries of the wrapping, np.angle's output,
         ###    and matplotlib's own copy)
@@ -297,8 +298,14 @@ def clip_wrapper(ifgix):
     unwfile = os.path.join(in_dir, ifgd, ifgd+'.unw')
     ccfile = os.path.join(in_dir, ifgd, ifgd+'.cc')
 
+    ### Read and clip. Copy because a slice is only a view, which would
+    ### keep the full-size array alive and, worse, make tofile write the
+    ### data element by element (10x slower on a local disk, ~80x on a
+    ### network/shared filesystem)
     unw = io_lib.read_img(unwfile, length, width)
     unw[unw==0] = np.nan
+    unw = unw[y1:y2, x1:x2].copy()
+
     if os.path.getsize(ccfile) == length*width:
         ccformat = np.uint8
     elif os.path.getsize(ccfile) == length*width*4:
@@ -307,10 +314,7 @@ def clip_wrapper(ifgix):
         print("ERROR: unkown file format for {}".format(ccfile), file=sys.stderr)
         return
     coh = io_lib.read_img(ccfile, length, width, dtype=ccformat)
-
-    ### Clip
-    unw = unw[y1:y2, x1:x2]
-    coh = coh[y1:y2, x1:x2]
+    coh = coh[y1:y2, x1:x2].copy()
 
     ### Output
     out_dir1 = os.path.join(out_dir, ifgd)

--- a/bin/LiCSBAS05op_clip_unw.py
+++ b/bin/LiCSBAS05op_clip_unw.py
@@ -64,7 +64,7 @@ def main(argv=None):
         argv = sys.argv
 
     start = time.time()
-    ver="1.2.6"; date=20250715; author="Y. Morishita"
+    ver="1.2.7"; date=20260905; author="Y. Morishita"
     print("\n{} ver{} {} {}".format(os.path.basename(argv[0]), ver, date, author), flush=True)
     print("{} {}".format(os.path.basename(argv[0]), ' '.join(argv[1:])), flush=True)
 
@@ -82,7 +82,6 @@ def main(argv=None):
     except:
         n_para = max(multi.cpu_count()-1, 1)
 
-    q = multi.get_context('fork')
     cmap_wrap = tools_lib.get_cmap('cm_insar')
 
 
@@ -264,9 +263,18 @@ def main(argv=None):
             n_para = n_ifg2
 
         print('  {} parallel processing...'.format(n_para), flush=True)
-        p = q.Pool(n_para)
-        p.map(clip_wrapper, range(n_ifg2))
-        p.close()
+        ### Approx memory use per worker (MB). n_para is capped by
+        ### tools_lib.run_pool with this value and the memory available at
+        ### the time of the parallel processing:
+        ###  - 2 float32 frames of the input size: unw and coh, which stay
+        ###    alive at full size because the clipped arrays are views
+        ###  - ~6 float32 frames of the clipped size for the png stage (the
+        ###    complex64 temporaries of the wrapping, np.angle's output,
+        ###    and matplotlib's own copy)
+        _mem_per_worker_mb = (2*length*width +
+                              6*length_c*width_c)*4/2**20
+        tools_lib.run_pool(clip_wrapper, range(n_ifg2), n_para,
+                           mem_per_worker_mb=_mem_per_worker_mb)
 
 
     #%% Finish
@@ -308,13 +316,16 @@ def clip_wrapper(ifgix):
     out_dir1 = os.path.join(out_dir, ifgd)
     if not os.path.exists(out_dir1): os.mkdir(out_dir1)
 
-    unw.tofile(os.path.join(out_dir1, ifgd+'.unw'))
     coh.tofile(os.path.join(out_dir1, ifgd+'.cc'))
 
     ## Output png for corrected unw
     pngfile = os.path.join(out_dir1, ifgd+'.unw.png')
     title = '{} ({}pi/cycle)'.format(ifgd, cycle*2)
     plot_lib.make_im_png(np.angle(np.exp(1j*unw/cycle)*cycle), pngfile, cmap_wrap, title, -np.pi, np.pi, cbar=False)
+
+    ## Output unw last, so that it does not exist if this worker is killed
+    ## (e.g. by the OOM killer) and the ifg is redone on a rerun
+    unw.tofile(os.path.join(out_dir1, ifgd+'.unw'))
 
 
 #%% main


### PR DESCRIPTION
Follow-up to #164, which fixed the same class of hang in steps 03/12/13/16. Steps 02, 04 and 05 still used a plain fork `Pool(n_para).map()`, so a worker killed by the OS out-of-memory killer left the run hanging forever.

## The bug

Reported on a 7.9 GB machine processing `124D_04854_171313/GEOC` (3710x3236 = 12.0 Mpx, 31 ifgs, nlook=1). step02 stopped after `30/31th IFG...` and never returned. The output directory showed why: two ifgs held a `.unw` and a `.cc` but no `.unw.png`, i.e. workers killed inside `make_im_png`. Reproduced under a cgroup, with `A process of this unit has been killed by the OOM killer` in the journal; the unpatched steps had to be SIGKILLed after 180 s.

A worker peaks at ~635 MB for this frame, of which the png stage (`np.angle(np.exp(1j*unw/cycle)*cycle)` plus matplotlib) is the larger half.

## Changes

**Migrate the three pools to `tools_lib.run_pool`**, which raises a clear error instead of hanging and caps `n_para` by the memory available just before the pool starts. Per-worker estimates are derived from what each wrapper allocates and checked against the measured peak RSS of a worker (1 frame = `length*width*4` B):

| step | estimate | estimated | measured |
|---|---|---|---|
| 02 `convert_wrapper` | 3 input frames + 6 output frames | 412 MB (nlook=1) | 402 MB |
| 04 `mask_wrapper` | 7 frames | 321 MB | 316 MB |
| 05 `clip_wrapper` | 2 input frames + 6 clipped frames | 336 MB | 342 MB |

step02 needs the input geotiff size before the pool, so a small probe opens the first readable unw tif; if none opens the estimate is 0 and `run_pool` applies no cap.

**Write the `.unw` last, after the png.** A worker killed during `make_im_png` used to leave a complete-looking `.unw` + `.cc` pair, which the "already exist" check skips on the next run, so the missing png was never created. Writing the `.unw` last makes such an ifg be redone.

**step05: copy the clipped arrays instead of keeping views.** `unw[y1:y2, x1:x2]` is a view, so the array handed to `tofile` is not C-contiguous and numpy writes it element by element:

| | view | copy | |
|---|---|---|---|
| clipped unw (40.7 MB), local disk | 0.139 s | 0.016 s | ~9x |
| clipped unw, VirtualBox shared folder | 1.678 s | 0.021 s | **~80x** |
| clipped cc (10.2 MB), local disk | 0.162 s | 0.006 s | ~27x |
| clipped cc, VirtualBox shared folder | 0.536 s | 0.008 s | ~67x |

step05 over the 31 ifgs with `n_para 4` on a shared filesystem: **120 s -> 42 s**. `unw` is now clipped before `coh` is read, so the two full-size arrays never coexist; the memory gain is small (worker peak 349 -> 342 MB near-full clip, 103 -> 92 MB for a 1.0 Mpx clip), so the estimate is unchanged and only its comment is corrected.

## Verification

On the real 31-ifg frame:

| check | step02 | step04 | step05 |
|---|---|---|---|
| unpatched under a 1500 MB cgroup | hang, SIGKILL at 180 s | hang, SIGKILL at 180 s | hang, SIGKILL at 180 s |
| patched, same conditions | error in 25 s | error in 11 s | error in 28 s |
| rerun after that abort | 31 ifgs complete | 31 ifgs complete | 31 ifgs complete |
| rerun output vs a clean run | byte-identical | byte-identical | byte-identical |
| `--n_para 20` on the 7.9 GB machine | `Reduce n_para from 20 to 5 (~412 MB/worker)` | `20 -> 6 (~321 MB/worker)` | `20 -> 6 (~335 MB/worker)` |
| output vs the previous code | byte-identical (nlook 1 and 4) | byte-identical incl. mask[.png] | byte-identical incl. par/aux |

`pytest`: 98 passed. `run_pool` itself, including the dead-worker path, is already covered by the tests added in #164.

## Note

`run_pool` reads `psutil.virtual_memory().available`, which reports the whole host, so the automatic cap does not see a cgroup or PBS memory limit (this is why `n_para` stayed at 5 in the cgroup tests above). The hang is fixed either way; making the cap cgroup-aware would touch every step and is left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)